### PR TITLE
Updates to temporal filtering

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/TemporalLiteral.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/TemporalLiteral.java
@@ -114,6 +114,8 @@ public interface TemporalLiteral extends Temporal, Literal, CqlNode {
                 }
             }*/
 
+            // If the datetime parameter uses dates, not timestamps, the result is always an interval that
+            // starts on the first second of the start date and ends at the last second of the end date.
             try {
                 if (INTERVAL_PATTERN.test(literal)) {
                     // a fully specified datetime interval
@@ -123,9 +125,13 @@ public interface TemporalLiteral extends Temporal, Literal, CqlNode {
                     return Instant.parse(literal);
                 } else if (DATE_PATTERN.test(literal)) {
                     // a date only instant
-                    return LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse(literal))
-                                    .atStartOfDay()
-                                    .toInstant(ZoneOffset.UTC);
+                    Instant start = LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse(literal))
+                                             .atStartOfDay()
+                                             .toInstant(ZoneOffset.UTC);
+                    Instant end = LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse(literal))
+                                           .atTime(23,59,59)
+                                           .toInstant(ZoneOffset.UTC);
+                    return Interval.of(start, end);
                 } else if (INTERVAL_OPEN_PATTERN.test(literal)) {
                     // open start and end
                     return Interval.of(MIN_DATE, MAX_DATE);
@@ -143,7 +149,7 @@ public interface TemporalLiteral extends Temporal, Literal, CqlNode {
                                              .atStartOfDay()
                                              .toInstant(ZoneOffset.UTC);
                     Instant end = LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse(literal.substring(literal.indexOf("/") + 1)))
-                                           .atStartOfDay()
+                                           .atTime(23,59,59)
                                            .toInstant(ZoneOffset.UTC);
                     return Interval.of(start, end);
                 } else if (DATE_INTERVAL_OPEN_END_PATTERN.test(literal)) {
@@ -155,7 +161,7 @@ public interface TemporalLiteral extends Temporal, Literal, CqlNode {
                 } else if (DATE_INTERVAL_OPEN_START_PATTERN.test(literal)) {
                     // start open, end date instant
                     Instant end = LocalDate.from(DateTimeFormatter.ISO_LOCAL_DATE.parse(literal.substring(literal.indexOf("/") + 1)))
-                                           .atStartOfDay()
+                                           .atTime(23,59,59)
                                            .toInstant(ZoneOffset.UTC);
                     return Interval.of(MIN_DATE, end);
                 }

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlJsonSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlJsonSpec.groovy
@@ -809,7 +809,7 @@ class CqlJsonSpec extends Specification {
         {
             "before": {
                 "property": "built",
-                "value": "2015-01-01T00:00:00Z"
+                "value": [ "2015-01-01T00:00:00Z", "2015-01-01T23:59:59Z" ]
             }
         }
         """
@@ -844,7 +844,7 @@ class CqlJsonSpec extends Specification {
             {
                 "during": {
                     "property": "updated",
-                    "value": ["2017-06-10T00:00:00Z","2017-06-11T00:00:00Z"]
+                    "value": ["2017-06-10T00:00:00Z","2017-06-11T23:59:59Z"]
                 }
             }
         """

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTextSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTextSpec.groovy
@@ -501,7 +501,7 @@ class CqlTextSpec extends Specification {
         String actual2 = cql.write(CqlFilterExamples.EXAMPLE_24, Cql.Format.TEXT)
 
         then:
-        actual2 == "built BEFORE 2015-01-01T00:00:00Z"
+        actual2 == "built BEFORE 2015-01-01T00:00:00Z/2015-01-01T23:59:59Z"
     }
 
     def 'Updated between June 10, 2017 and June 11, 2017'() {
@@ -520,7 +520,7 @@ class CqlTextSpec extends Specification {
         String actual2 = cql.write(CqlFilterExamples.EXAMPLE_25, Cql.Format.TEXT)
 
         then:
-        actual2 == "updated DURING 2017-06-10T00:00:00Z/2017-06-11T00:00:00Z"
+        actual2 == "updated DURING 2017-06-10T00:00:00Z/2017-06-11T23:59:59Z"
     }
 
     def 'Updated between 7:30am June 10, 2017 and open end date'() {

--- a/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
+++ b/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
@@ -10,35 +10,8 @@ package de.ii.xtraplatform.feature.provider.sql.app;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Doubles;
-import de.ii.xtraplatform.cql.domain.CqlToText;
-import de.ii.xtraplatform.cql.domain.Between;
-import de.ii.xtraplatform.cql.domain.CqlFilter;
-import de.ii.xtraplatform.cql.domain.During;
-import de.ii.xtraplatform.cql.domain.Geometry;
+import de.ii.xtraplatform.cql.domain.*;
 import de.ii.xtraplatform.cql.domain.Geometry.Coordinate;
-import de.ii.xtraplatform.cql.domain.ImmutableAfter;
-import de.ii.xtraplatform.cql.domain.ImmutableBefore;
-import de.ii.xtraplatform.cql.domain.ImmutableContains;
-import de.ii.xtraplatform.cql.domain.ImmutableCrosses;
-import de.ii.xtraplatform.cql.domain.ImmutableDisjoint;
-import de.ii.xtraplatform.cql.domain.ImmutableDuring;
-import de.ii.xtraplatform.cql.domain.ImmutableEquals;
-import de.ii.xtraplatform.cql.domain.ImmutableIntersects;
-import de.ii.xtraplatform.cql.domain.ImmutableOverlaps;
-import de.ii.xtraplatform.cql.domain.ImmutablePolygon;
-import de.ii.xtraplatform.cql.domain.ImmutableTEquals;
-import de.ii.xtraplatform.cql.domain.ImmutableTOverlaps;
-import de.ii.xtraplatform.cql.domain.ImmutableTouches;
-import de.ii.xtraplatform.cql.domain.ImmutableWithin;
-import de.ii.xtraplatform.cql.domain.In;
-import de.ii.xtraplatform.cql.domain.IsNull;
-import de.ii.xtraplatform.cql.domain.Like;
-import de.ii.xtraplatform.cql.domain.Property;
-import de.ii.xtraplatform.cql.domain.ScalarOperation;
-import de.ii.xtraplatform.cql.domain.SpatialOperation;
-import de.ii.xtraplatform.cql.domain.TOverlaps;
-import de.ii.xtraplatform.cql.domain.TemporalLiteral;
-import de.ii.xtraplatform.cql.domain.TemporalOperation;
 import de.ii.xtraplatform.crs.domain.CrsTransformer;
 import de.ii.xtraplatform.crs.domain.CrsTransformerFactory;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
@@ -276,6 +249,50 @@ public class FilterEncoderSqlNewNewImpl implements FilterEncoderSqlNewNew {
 
             // ISO 8601 intervals include both the start and end instant
             // PostgreSQL intervals are exclusive of the end instant, so we add one second to each end instant
+
+            if (temporalOperation instanceof Before) {
+                TemporalLiteral operand2 = (TemporalLiteral) temporalOperation.getOperands()
+                                                                              .get(1);
+
+                String literalInstant;
+
+                if (operand2.getType() == Interval.class) {
+                    Interval interval = (Interval) temporalOperation.getValue()
+                                                                    .get()
+                                                                    .getValue();
+                    literalInstant = String.format("TIMESTAMP '%s'", interval.getStart());
+                    literalInstant = literalInstant.replaceAll("'0000-01-01T00:00:00Z'", "'-infinity'");
+                } else {
+                    Instant instant = (Instant) temporalOperation.getValue()
+                                                                 .get()
+                                                                 .getValue();
+                    literalInstant = String.format("TIMESTAMP '%s'", instant);
+                }
+
+                return String.format(expression, "", String.format(" %s %s", operator, literalInstant));
+            }
+
+            if (temporalOperation instanceof After) {
+                TemporalLiteral operand2 = (TemporalLiteral) temporalOperation.getOperands()
+                                                                              .get(1);
+
+                String literalInstant;
+
+                if (operand2.getType() == Interval.class) {
+                    Interval interval = (Interval) temporalOperation.getValue()
+                                                                    .get()
+                                                                    .getValue();
+                    literalInstant = String.format("TIMESTAMP '%s'", interval.getEnd());
+                    literalInstant = literalInstant.replaceAll("'9999-12-31T23:59:59Z'", "'infinity'");
+                } else {
+                    Instant instant = (Instant) temporalOperation.getValue()
+                                                                 .get()
+                                                                 .getValue();
+                    literalInstant = String.format("TIMESTAMP '%s'", instant);
+                }
+
+                return String.format(expression, "", String.format(" %s %s", operator, literalInstant));
+            }
 
             if (temporalOperation instanceof During) {
                 Interval interval = (Interval) temporalOperation.getValue()

--- a/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
+++ b/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
@@ -276,7 +276,7 @@ public class FilterEncoderSqlNewNewImpl implements FilterEncoderSqlNewNew {
 
             // ISO 8601 intervals include both the start and end instant
             // PostgreSQL intervals are exclusive of the end instant, so we add one second to each end instant
-            
+
             if (temporalOperation instanceof During) {
                 Interval interval = (Interval) temporalOperation.getValue()
                                                                 .get()

--- a/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
+++ b/xtraplatform-feature-provider-sql/src/main/java/de/ii/xtraplatform/feature/provider/sql/app/FilterEncoderSqlNewNewImpl.java
@@ -294,9 +294,8 @@ public class FilterEncoderSqlNewNewImpl implements FilterEncoderSqlNewNew {
                                                                                                                .toString()));
                 }
 
-                String[] interval2 = children.get(1)
-                                             .split("/");
-                return String.format(expression, "", String.format(" %s TIMESTAMP %s' AND TIMESTAMP '%s", operator, interval2[0], interval.getEnd()
+                return String.format(expression, "", String.format(" %s TIMESTAMP '%s' AND TIMESTAMP '%s'", operator, interval.getStart()
+                                                                                                                              .toString(), interval.getEnd()
                                                                                                                                           .plusSeconds(1)
                                                                                                                                           .toString()));
             }
@@ -313,7 +312,8 @@ public class FilterEncoderSqlNewNewImpl implements FilterEncoderSqlNewNew {
                                                                     .getValue();
                     literalInterval = String.format("(TIMESTAMP '%s', TIMESTAMP '%s')", interval.getStart(), interval.getEnd()
                                                                                                                      .plusSeconds(1));
-                    literalInterval = literalInterval.replaceAll("0000-01-01T00:00:00Z", "-infinity");
+                    literalInterval = literalInterval.replaceAll("'0000-01-01T00:00:00Z'", "'-infinity'");
+                    literalInterval = literalInterval.replaceAll("'\\+10000-01-01T00:00:00Z'", "'infinity'");
                 } else {
                     Instant instant = (Instant) temporalOperation.getValue()
                                                                  .get()


### PR DESCRIPTION
* If the `datetime` parameter uses dates, not timestamps, an interval that starts on the first second of the start date and ends at the last second of the end date is used.
* ISO 8601 intervals include both the start and end instant. PostgreSQL intervals are exclusive of the end instant, so we have to add one second to each end instant before creating the SQL interval.