### PR TITLE
Support envelopes that span the anti-meridian

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ ext {
     versionSuffix = project.findProperty('snapshot') == 'true' ? '-SNAPSHOT' : ''
 }
 
-version = '4.6.1' + versionSuffix
+version = '4.7.0' + versionSuffix
 
 dependencies {
     feature group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '3.5.1'


### PR DESCRIPTION
closes interactive-instruments/ldproxy#447

Note that the current code is not robust with respect to envelopes in other CRSs that are not the default CRSs. We should be able to get the necessary information from the CRS (what is the max and min longitude/easting value?), but this requires a more complex change to how we deal with CRSs. Perhaps this could be addressed as part of interactive-instruments/ldproxy#439.