### PR TITLE
Fixes to issues with WFS backends

### DIFF
--- a/xtraplatform-feature-provider-wfs/src/main/java/de/ii/xtraplatform/feature/provider/wfs/GMLSchemaParser.java
+++ b/xtraplatform-feature-provider-wfs/src/main/java/de/ii/xtraplatform/feature/provider/wfs/GMLSchemaParser.java
@@ -281,8 +281,9 @@ public class GMLSchemaParser {
 
         if (propertyType.isSimpleType()) {
             if (propertyType.asSimpleType().getPrimitiveType() != null) {
-                propertyType = propertyType.asSimpleType().getPrimitiveType();
-                propertyTypeName = propertyType.getName();
+                propertyTypeName = propertyType.asSimpleType().getName().matches("int|long")
+                        ? "int"
+                        : propertyType.asSimpleType().getPrimitiveType().getName();
             } else if (propertyType.asSimpleType().asUnion() != null) {
                 propertyTypeName = "string";
             }

--- a/xtraplatform-feature-provider-wfs/src/main/java/de/ii/xtraplatform/feature/provider/wfs/infra/WfsSchemaAnalyzer.java
+++ b/xtraplatform-feature-provider-wfs/src/main/java/de/ii/xtraplatform/feature/provider/wfs/infra/WfsSchemaAnalyzer.java
@@ -152,6 +152,8 @@ class WfsSchemaAnalyzer implements FeatureProviderSchemaConsumer {
             Optional<FeatureSchema.Type> propertyType = getPropertyType(type, isParentMultiple, isComplex, isObject);
             if (propertyType.isPresent()) {
                 String fieldNameGml = currentPath.toFieldNameGml();
+                if (fieldNameGml.equals("id"))
+                    fieldNameGml = "_id_";
                 property.name(getShortPropertyName(fieldNameGml))
                         .sourcePath(getSourcePath(currentPath.asList()))
                         .type(propertyType.get());

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureType.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureType.java
@@ -79,7 +79,11 @@ public interface FeatureType extends Buildable<FeatureType> {
                                                            for (Map.Entry<String, String> entry : getAdditionalInfo().entrySet()) {
                                                                String prefix = entry.getKey();
                                                                String uri = entry.getValue();
-                                                               resolvedElement = resolvedElement.replaceAll(prefix + ":", uri + ":");
+                                                               if (prefix.isBlank()) {
+                                                                   if (resolvedElement.startsWith(":"))
+                                                                       resolvedElement = uri + resolvedElement;
+                                                               } else
+                                                                   resolvedElement = resolvedElement.replaceAll(prefix + ":", uri + ":");
                                                            }
 
                                                            return resolvedElement;


### PR DESCRIPTION
- avoid collisions with feature properties "id" (reserved for `@gml:id`); the property is now mapped to `_id_` to avoid the collision
- an empty (default) namespace prefix caused errors in the feature output
- integers were mapped to FLOAT, not INTEGER

closes https://github.com/interactive-instruments/ldproxy/issues/454

