### PR TITLE
add schema role TYPE

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProperty.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProperty.java
@@ -24,7 +24,8 @@ public interface FeatureProperty extends Buildable<FeatureProperty> {
     //TODO: Role with ID, SPATIAL, TEMPORAL, REFERENCE, REFERENCE_EMBED
     //TODO: more specific types, in addition or instead of Type
     enum Role {
-        ID
+        ID,
+        TYPE
     }
 
     enum Type {
@@ -68,6 +69,13 @@ public interface FeatureProperty extends Buildable<FeatureProperty> {
     @Value.Auxiliary
     default boolean isId() {
         return getRole().filter(role -> role == Role.ID).isPresent();
+    }
+
+    @JsonIgnore
+    @Value.Derived
+    @Value.Auxiliary
+    default boolean isType() {
+        return getRole().filter(role -> role == Role.TYPE).isPresent();
     }
 
     @JsonIgnore

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
@@ -21,11 +21,12 @@ import org.immutables.value.Value;
 public interface SchemaBase<T extends SchemaBase<T>> {
 
     enum Role {
-    ID,
-    GEOMETRY,
-    POINT_IN_TIME,
-    PERIOD_START,
-    PERIOD_END
+        ID,
+        GEOMETRY,
+        POINT_IN_TIME,
+        PERIOD_START,
+        PERIOD_END,
+        TYPE
     }
 
     enum Type {


### PR DESCRIPTION
The role identifies the type name of the object/feature and can be used, for example, in the JSON-LD `@type` annotation.