### PR TITLE
fix primary temporal property detection

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
@@ -103,9 +103,11 @@ public interface SchemaBase<T extends SchemaBase<T>> {
         return getProperties().stream()
             .filter(t -> t.getRole().filter(role -> role == Role.PRIMARY_INSTANT).isPresent())
             .findFirst()
-            .or(() -> getProperties().stream()
-                .filter(SchemaBase::isTemporal)
-                .findFirst());
+            .or(() -> getPrimaryInterval().isEmpty()
+                    ? getProperties().stream()
+                                     .filter(SchemaBase::isTemporal)
+                                     .findFirst()
+                    : Optional.empty());
     }
 
     @JsonIgnore


### PR DESCRIPTION
currently, the start of a primary interval is in typical cases mapped to primary instant