### PR TITLE
Add type checks for CQL2 expressions

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -102,6 +103,13 @@ public class CqlImpl implements Cql {
     @Override
     public List<String> findInvalidProperties(CqlPredicate cqlPredicate, Collection<String> validProperties) {
         CqlPropertyChecker visitor = new CqlPropertyChecker(validProperties);
+
+        return cqlPredicate.accept(visitor);
+    }
+
+    @Override
+    public List<String> findIncompatibleTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes) {
+        CqlTypeChecker visitor = new CqlTypeChecker(propertyTypes, this);
 
         return cqlPredicate.accept(visitor);
     }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
@@ -108,10 +108,10 @@ public class CqlImpl implements Cql {
     }
 
     @Override
-    public List<String> findIncompatibleTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes) {
+    public void checkTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes) {
         CqlTypeChecker visitor = new CqlTypeChecker(propertyTypes, this);
 
-        return cqlPredicate.accept(visitor);
+        cqlPredicate.accept(visitor);
     }
 
     @Override

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
@@ -1,0 +1,228 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.app;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import de.ii.xtraplatform.cql.domain.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class CqlTypeChecker extends CqlVisitorBase<List<String>> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CqlTypeChecker.class);
+
+    private static final String UNKNOWN = "UNKNOWN";
+
+    private static final List<List<String>> SCALARS = ImmutableList.of(
+        ImmutableList.of("String", UNKNOWN),
+        ImmutableList.of("Boolean", UNKNOWN),
+        ImmutableList.of("LocalDate", UNKNOWN),
+        ImmutableList.of("Instant", UNKNOWN),
+        ImmutableList.of("Integer", "Long", "Double", UNKNOWN)
+    );
+
+    private static final List<List<String>> SCALARS_ORDERED = ImmutableList.of(
+        ImmutableList.of("String", UNKNOWN),
+        ImmutableList.of("LocalDate", UNKNOWN),
+        ImmutableList.of("Instant", UNKNOWN),
+        ImmutableList.of("Integer", "Long", "Double", UNKNOWN)
+    );
+
+    private static final List<List<String>> NUMBERS = ImmutableList.of(
+        ImmutableList.of("Integer", "Long", "Double", UNKNOWN)
+    );
+
+    private static final List<List<String>> TEXTS = ImmutableList.of(
+        ImmutableList.of("String", UNKNOWN)
+    );
+
+    private static final List<List<String>> TEMPORALS = ImmutableList.of(
+        ImmutableList.of("LocalDate", "Instant", "Interval", UNKNOWN)
+    );
+
+    private static final List<List<String>> SPATIALS = ImmutableList.of(
+        // TODO geometry types, some of the operations only accept a subset or certain combinations of the geometry types
+        ImmutableList.of("Geometry", UNKNOWN)
+    );
+
+    private static final List<List<String>> ARRAYS = ImmutableList.of(
+        ImmutableList.of("List", UNKNOWN)
+    );
+
+    private static final Map<Class<?>,List<List<String>>> COMPATIBILITY =
+        new ImmutableMap.Builder<Class<?>,List<List<String>>>()
+            .put(ImmutableEq.class, SCALARS)
+            .put(ImmutableNeq.class, SCALARS)
+            .put(ImmutableLt.class, SCALARS_ORDERED)
+            .put(ImmutableLte.class, SCALARS_ORDERED)
+            .put(ImmutableGt.class, SCALARS_ORDERED)
+            .put(ImmutableGte.class, SCALARS_ORDERED)
+            .put(ImmutableLike.class, TEXTS)
+            .put(ImmutableIn.class, SCALARS)
+            .put(ImmutableBetween.class, NUMBERS)
+            .put(ImmutableTemporalOperation.class, TEMPORALS)
+            .put(ImmutableSpatialOperation.class, SPATIALS)
+            .put(ImmutableArrayOperation.class, ARRAYS)
+            .build();
+
+    private final Map<String, String> propertyTypes;
+    private final List<String> invalidPredicates = new ArrayList<>();
+    private final Cql cql;
+
+    public CqlTypeChecker(Map<String, String> propertyTypes, Cql cql) {
+        this.propertyTypes = propertyTypes;
+        this.cql = cql;
+    }
+
+    @Override
+    public List<String> visit(CqlFilter cqlFilter, List<List<String>> children) {
+        ImmutableList<String> result = ImmutableList.copyOf(invalidPredicates);
+        invalidPredicates.clear();
+        return result;
+    }
+
+    @Override
+    public List<String> visit(BinaryScalarOperation scalarOperation, List<List<String>> children) {
+        checkBinaryOperation(scalarOperation);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(In in, List<List<String>> children) {
+        final List<List<String>> compatibilityList = COMPATIBILITY.get(in.getClass());
+        final String type1 = getType(in.getValue().orElse(null));
+        in.getList().stream()
+            .map(this::getType)
+            .forEach(type2 -> checkOperation(compatibilityList, type1, type2, in));
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(Like like, List<List<String>> children) {
+        final List<List<String>> compatibilityList = COMPATIBILITY.get(like.getClass());
+        String type1 = getType(like.getOperands().get(0));
+        String type2 = getType(like.getOperands().get(1));
+        checkOperation(compatibilityList, type1, type2, like);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(Between between, List<List<String>> children) {
+        final List<List<String>> compatibilityList = COMPATIBILITY.get(between.getClass());
+        final String type1 = getType(between.getValue().orElse(null));
+        final String type2 = getType(between.getLower().orElse(null));
+        final String type3 = getType(between.getUpper().orElse(null));
+        checkOperation(compatibilityList, type1, type2, between);
+        checkOperation(compatibilityList, type1, type3, between);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(TemporalOperation temporalOperation, List<List<String>> children) {
+        checkBinaryOperation(temporalOperation);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(SpatialOperation spatialOperation, List<List<String>> children) {
+        checkBinaryOperation(spatialOperation);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(ArrayOperation arrayOperation, List<List<String>> children) {
+        checkBinaryOperation(arrayOperation);
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<String> visit(Function function, List<List<String>> children) {
+        if (function.isInterval()) {
+            checkFunction(TEMPORALS,
+                          function.getArguments().stream()
+                              .map(this::getType)
+                              .collect(Collectors.toUnmodifiableList()),
+                          function);
+        } else if (function.isUpper() || function.isLower() || function.isCasei() || function.isAccenti()) {
+            checkFunction(TEXTS,
+                          function.getArguments().stream()
+                              .map(this::getType)
+                              .collect(Collectors.toUnmodifiableList()),
+                          function);
+        }
+        return Lists.newArrayList();
+    }
+
+    private void checkBinaryOperation(BinaryOperation<?> predicate) {
+        final List<List<String>> compatibilityList = COMPATIBILITY.get(predicate.getClass());
+        String type1 = getType(predicate.getOperands().get(0));
+        String type2 = getType(predicate.getOperands().get(1));
+        checkOperation(compatibilityList, type1, type2, predicate);
+    }
+
+    private void checkOperation(List<List<String>> compatibilityList, String type1, String type2, CqlNode node) {
+        if (Objects.nonNull(compatibilityList) &&
+            compatibilityList.stream()
+                .noneMatch(compatibleTypes -> compatibleTypes.contains(type1) && compatibleTypes.contains(type2))) {
+            invalidPredicates.add(cql.write(CqlFilter.of(node), Cql.Format.TEXT));
+        }
+    }
+
+    private void checkFunction(List<List<String>> compatibilityList, List<String> types, Function function) {
+        if (Objects.nonNull(compatibilityList) &&
+            compatibilityList.stream()
+                .noneMatch(compatibleTypes -> compatibleTypes.containsAll(types))) {
+            invalidPredicates.add(cql.write(CqlFilter.of(Eq.ofFunction(function,ScalarLiteral.of("DUMMY"))), Cql.Format.TEXT).replace(" = 'DUMMY'", ""));
+        }
+    }
+
+    private String getType(Operand operand) {
+        if (Objects.isNull(operand)) {
+            return UNKNOWN;
+        } else if (operand instanceof Function) {
+            return ((Function) operand).getType().getSimpleName();
+        } else if (operand instanceof SpatialLiteral) {
+            return "Geometry";
+        } else if (operand instanceof Literal) {
+            return ((Literal)operand).getType().getSimpleName();
+        } else if (operand instanceof Property) {
+            String schemaType = propertyTypes.get(((Property)operand).getName());
+            if (Objects.nonNull(schemaType))
+                switch (schemaType) {
+                    case "STRING":
+                        return "String";
+                    case "INTEGER":
+                        return "Integer";
+                    case "FLOAT":
+                        return "Double";
+                    case "BOOLEAN":
+                        return "Boolean";
+                    case "DATETIME":
+                        return "Instant";
+                    case "DATE":
+                        return "LocalDate";
+                    case "GEOMETRY":
+                        return "Geometry";
+                    case "OBJECT":
+                        return "Object";
+                    case "VALUE_ARRAY":
+                    case "OBJECT_ARRAY":
+                        return "List";
+                }
+        }
+        return UNKNOWN;
+    }
+}

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
@@ -177,7 +177,9 @@ public class CqlTypeChecker extends CqlVisitorBase<List<String>> {
         if (Objects.nonNull(compatibilityList) &&
             compatibilityList.stream()
                 .noneMatch(compatibleTypes -> compatibleTypes.contains(type1) && compatibleTypes.contains(type2))) {
-            invalidPredicates.add(cql.write(CqlFilter.of(node), Cql.Format.TEXT));
+            String predicateText = cql.write(CqlFilter.of(node), Cql.Format.TEXT);
+            if (!invalidPredicates.contains(predicateText))
+                invalidPredicates.add(predicateText);
         }
     }
 
@@ -185,7 +187,10 @@ public class CqlTypeChecker extends CqlVisitorBase<List<String>> {
         if (Objects.nonNull(compatibilityList) &&
             compatibilityList.stream()
                 .noneMatch(compatibleTypes -> compatibleTypes.containsAll(types))) {
-            invalidPredicates.add(cql.write(CqlFilter.of(Eq.ofFunction(function,ScalarLiteral.of("DUMMY"))), Cql.Format.TEXT).replace(" = 'DUMMY'", ""));
+            String functionText = cql.write(CqlFilter.of(Eq.ofFunction(function,ScalarLiteral.of("DUMMY"))), Cql.Format.TEXT)
+                .replace(" = 'DUMMY'", "");
+            if (!invalidPredicates.contains(functionText))
+                invalidPredicates.add(functionText);
         }
     }
 

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlTypeChecker.java
@@ -200,12 +200,11 @@ public class CqlTypeChecker extends CqlVisitorBase<Type> {
         if (Objects.isNull(compatibilityLists))
             throw new CqlIncompatibleTypes(getText(node), firstType.schemaType(), ImmutableList.of());
         if (compatibilityLists.stream().noneMatch(list -> list.contains(firstType)))
-            throw new CqlIncompatibleTypes(getText(node), firstType.schemaType(),
-                                           compatibilityLists.stream()
-                                               .flatMap(Collection::stream)
-                                               .distinct()
-                                               .map(Type::schemaType)
-                                               .collect(Collectors.toUnmodifiableList()));
+            throw new CqlIncompatibleTypes(getText(node),
+                                           firstType.schemaType(),
+                                           asSchemaTypes(compatibilityLists.stream()
+                                                             .flatMap(Collection::stream)
+                                                             .collect(Collectors.toUnmodifiableList())));
 
         final List<Type> compatibleTypes = Objects.requireNonNullElse(COMPATIBILITY_PREDICATES.get(node.getClass()),
                                                                       ImmutableList.of(ImmutableList.<Type>of()))
@@ -238,7 +237,7 @@ public class CqlTypeChecker extends CqlVisitorBase<Type> {
     }
 
     private List<String> asSchemaTypes(List<Type> types) {
-        return types.stream().map(Type::schemaType).collect(Collectors.toUnmodifiableList());
+        return types.stream().map(Type::schemaType).distinct().collect(Collectors.toUnmodifiableList());
     }
 
     private void check(List<Type> types, List<Type> expectedTypes, CqlNode node) {

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/Type.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/Type.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.app;
+
+public enum Type {
+    String, Boolean, Integer, Long, Double,
+    LocalDate, Instant, Interval, OPEN,
+    Geometry,
+    List,
+    UNKNOWN;
+
+    public String schemaType() {
+        switch (this) {
+            case String:
+                return "STRING";
+            case Boolean:
+                return "BOOLEAN";
+            case Integer:
+            case Long:
+                return "INTEGER";
+            case Double:
+                return "FLOAT";
+            case LocalDate:
+                return "DATE";
+            case OPEN:
+            case Instant:
+                return "DATETIME";
+            case Interval:
+                return "STRING";
+            case Geometry:
+                return "GEOMETRY";
+            case List:
+                return "ARRAY";
+            default:
+                return "unknown";
+        }
+    }
+}

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
@@ -11,6 +11,7 @@ import de.ii.xtraplatform.crs.domain.EpsgCrs;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public interface Cql {
@@ -24,6 +25,8 @@ public interface Cql {
     String write(CqlFilter cql, Format format);
 
     List<String> findInvalidProperties(CqlPredicate cqlPredicate, Collection<String> validProperties);
+
+    List<String> findIncompatibleTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes);
 
     CqlNode mapTemporalOperators(CqlFilter cqlFilter, Set<TemporalOperator> supportedOperators);
 }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
@@ -26,7 +26,7 @@ public interface Cql {
 
     List<String> findInvalidProperties(CqlPredicate cqlPredicate, Collection<String> validProperties);
 
-    List<String> findIncompatibleTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes);
+    void checkTypes(CqlPredicate cqlPredicate, Map<String, String> propertyTypes);
 
     CqlNode mapTemporalOperators(CqlFilter cqlFilter, Set<TemporalOperator> supportedOperators);
 }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlIncompatibleTypes.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlIncompatibleTypes.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.infra;
+
+import java.util.List;
+
+public class CqlIncompatibleTypes extends IllegalArgumentException {
+  public CqlIncompatibleTypes(String cqlText, String type, List<String> expectedTypes) {
+    super(String.format("Incompatible types in CQL2 filter. Found type '%s' in expression [%s]. Expected types: %s", type, cqlText, String.join(", ", expectedTypes)));
+  }
+  public CqlIncompatibleTypes(String cqlText, List<String> types, List<String> expectedTypes) {
+    super(String.format("Incompatible types in CQL2 filter. Expression [%s] has types: %s. Expected types: %s", cqlText, String.join(", ", types), String.join(", ", expectedTypes)));
+  }
+}

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.app
+
+import com.google.common.collect.ImmutableMap
+import de.ii.xtraplatform.cql.domain.Cql
+import de.ii.xtraplatform.cql.domain.CqlFilter
+import de.ii.xtraplatform.cql.domain.CqlPredicate
+import de.ii.xtraplatform.cql.domain.Or
+import de.ii.xtraplatform.cql.domain.Lt
+import de.ii.xtraplatform.cql.domain.Gt
+import de.ii.xtraplatform.cql.domain.ScalarLiteral
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CqlTypeCheckerSpec extends Specification {
+
+    @Shared
+    Cql cql
+
+    @Shared
+    CqlTypeChecker visitor
+
+    def setupSpec() {
+        cql = new CqlImpl()
+        def propertyTypes = ImmutableMap.of("road_class", "STRING", "length", "FLOAT")
+        visitor = new CqlTypeChecker(propertyTypes, cql)
+    }
+
+    def 'Test the predicate-checking visitor'() {
+        given:
+        // run the test on 2 different queries to make sure that old reports are removed
+
+        when:
+        def test1 = CqlFilter.of(
+                Or.of(
+                        CqlPredicate.of(Gt.of("road_class", ScalarLiteral.of(1))),
+                        CqlPredicate.of(Lt.of("length", ScalarLiteral.of(1)))
+                )).accept(visitor)
+
+        then:
+        test1.size() == 1
+        test1.get(0) == "road_class > 1"
+
+        and:
+
+        when:
+        def test2 = CqlFilter.of(Gt.of("road_class", ScalarLiteral.of("1"))).accept(visitor)
+
+        then:
+        test2.size() == 0
+    }
+
+    def 'CASEI must be Strings'() {
+        given:
+        String cqlText = "CASEI(length) IN (CASEI('Οδος'), CASEI('Straße'))"
+
+        when: 'reading text'
+        def test = cql.read(cqlText, Cql.Format.TEXT).accept(visitor)
+
+        then:
+        test.size() == 1
+        test.get(0) == "CASEI(length)"
+    }
+
+    // these are tested with a different visitor
+    def 'Ignore invalid properties'() {
+        given:
+        String cqlText = "dummy = 'dummy'"
+
+        when: 'reading text'
+        def test = cql.read(cqlText, Cql.Format.TEXT).accept(visitor)
+
+        then:
+        test.size() == 0
+    }
+
+}

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
@@ -15,6 +15,7 @@ import de.ii.xtraplatform.cql.domain.Or
 import de.ii.xtraplatform.cql.domain.Lt
 import de.ii.xtraplatform.cql.domain.Gt
 import de.ii.xtraplatform.cql.domain.ScalarLiteral
+import de.ii.xtraplatform.cql.infra.CqlIncompatibleTypes
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -37,23 +38,22 @@ class CqlTypeCheckerSpec extends Specification {
         // run the test on 2 different queries to make sure that old reports are removed
 
         when:
-        def test1 = CqlFilter.of(
+        CqlFilter.of(
                 Or.of(
                         CqlPredicate.of(Gt.of("road_class", ScalarLiteral.of(1))),
                         CqlPredicate.of(Lt.of("length", ScalarLiteral.of(1)))
                 )).accept(visitor)
 
         then:
-        test1.size() == 1
-        test1.get(0).startsWith("road_class > 1")
+        thrown CqlIncompatibleTypes
 
         and:
 
         when:
-        def test2 = CqlFilter.of(Gt.of("road_class", ScalarLiteral.of("1"))).accept(visitor)
+        CqlFilter.of(Gt.of("road_class", ScalarLiteral.of("1"))).accept(visitor)
 
         then:
-        test2.size() == 0
+        noExceptionThrown()
     }
 
     def 'CASEI must be Strings'() {
@@ -64,8 +64,7 @@ class CqlTypeCheckerSpec extends Specification {
         def test = cql.read(cqlText, Cql.Format.TEXT).accept(visitor)
 
         then:
-        test.size() == 1
-        test.get(0).startsWith("CASEI(length);")
+        thrown CqlIncompatibleTypes
     }
 
     // these are tested with a different visitor
@@ -77,7 +76,7 @@ class CqlTypeCheckerSpec extends Specification {
         def test = cql.read(cqlText, Cql.Format.TEXT).accept(visitor)
 
         then:
-        test.size() == 0
+        noExceptionThrown()
     }
 
 }

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
@@ -45,7 +45,7 @@ class CqlTypeCheckerSpec extends Specification {
 
         then:
         test1.size() == 1
-        test1.get(0) == "road_class > 1"
+        test1.get(0).startsWith("road_class > 1")
 
         and:
 
@@ -65,7 +65,7 @@ class CqlTypeCheckerSpec extends Specification {
 
         then:
         test.size() == 1
-        test.get(0) == "CASEI(length)"
+        test.get(0).startsWith("CASEI(length);")
     }
 
     // these are tested with a different visitor


### PR DESCRIPTION
The only missing type information is for the properties, which is derived from the feature schema. Since the CQL2 module has no dependency to the features module, the type information is passed as a string. In error messages, the known types from the schema definitions are used, not the types used internally in the CQL2 implementation.