### PR TITLE
CQL2: improve handling of temporal data types

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/Type.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/Type.java
@@ -28,10 +28,11 @@ public enum Type {
             case LocalDate:
                 return "DATE";
             case OPEN:
+                return "UNBOUNDED_START_OR_END";
             case Instant:
                 return "DATETIME";
             case Interval:
-                return "STRING";
+                return "INTERVAL";
             case Geometry:
                 return "GEOMETRY";
             case List:

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlIncompatibleTypes.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlIncompatibleTypes.java
@@ -8,12 +8,17 @@
 package de.ii.xtraplatform.cql.infra;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class CqlIncompatibleTypes extends IllegalArgumentException {
   public CqlIncompatibleTypes(String cqlText, String type, List<String> expectedTypes) {
-    super(String.format("Incompatible types in CQL2 filter. Found type '%s' in expression [%s]. Expected types: %s", type, cqlText, String.join(", ", expectedTypes)));
+    super(String.format("Incompatible types in CQL2 filter. Found type '%s' in expression [%s]. Valid types: %s", type, cqlText, String.join(", ", expectedTypes)));
   }
   public CqlIncompatibleTypes(String cqlText, List<String> types, List<String> expectedTypes) {
-    super(String.format("Incompatible types in CQL2 filter. Expression [%s] has types: %s. Expected types: %s", cqlText, String.join(", ", types), String.join(", ", expectedTypes)));
+    super(String.format("Incompatible types in CQL2 filter. Expression [%s] has types: %s. Valid types: %s", cqlText, String.join(", ", types), String.join(", ", expectedTypes)));
+  }
+  public CqlIncompatibleTypes(String cqlText, List<String> types, Set<List<String>> expectedTypes) {
+    super(String.format("Incompatible types in CQL2 filter. Expression [%s] has types: %s. Valid type combinations: [%s]", cqlText, String.join(", ", types), expectedTypes.stream().map(typeList -> String.join(", ", typeList)).collect(Collectors.joining("] or ["))));
   }
 }

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlTypeCheckerSpec.groovy
@@ -99,5 +99,17 @@ class CqlTypeCheckerSpec extends Specification {
         noExceptionThrown()
     }
 
+    def 'interval of date and timestamp'() {
+        given:
+        String cqlText = "T_INTERSECTS(TIMESTAMP('2011-12-26T20:55:27Z'), INTERVAL('2011-01-01','2011-12-31T23:59:59Z')) OR " +
+                "T_INTERSECTS(INTERVAL('..','2011-12-31'), INTERVAL(begin,end)) OR " +
+                "T_BEFORE(event,DATE('2000-01-01'))"
+
+        when: 'reading text'
+        def test = cql.read(cqlText, Cql.Format.TEXT).accept(visitor)
+
+        then:
+        thrown CqlIncompatibleTypes
+    }
 
 }

--- a/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
+++ b/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
@@ -65,6 +65,7 @@ public class CqlFilterExamples {
     ));
 
     public static final CqlFilter EXAMPLE_12 = CqlFilter.of(TemporalOperation.of(TemporalOperator.T_BEFORE, "built", TemporalLiteral.of("2012-06-05T00:00:00Z")));
+    public static final CqlFilter EXAMPLE_12_date = CqlFilter.of(TemporalOperation.of(TemporalOperator.T_BEFORE, "built", TemporalLiteral.of("2012-06-05")));
 
     public static final CqlFilter EXAMPLE_12_alt = CqlFilter.of(Lt.of(ImmutableList.of(Property.of("built"), TemporalLiteral.of("2012-06-05T00:00:00Z"))));
     public static final CqlFilter EXAMPLE_12eq_alt = CqlFilter.of(Lte.of(ImmutableList.of(Property.of("built"), TemporalLiteral.of("2012-06-05T00:00:00Z"))));

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FilterEncoderSqlSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FilterEncoderSqlSpec.groovy
@@ -58,14 +58,31 @@ class FilterEncoderSqlSpec extends Specification {
 
     }
 
-    def 'temporal operation, instant'() {
+    def 'temporal operation, timestamp'() {
 
         given:
-        def instanceContainer = QuerySchemaFixtures.SIMPLE_INSTANT
+        def instanceContainer = QuerySchemaFixtures.SIMPLE_TIMESTAMP
         def filter = CqlFilterExamples.EXAMPLE_12
 
         when:
         String expected = "A.id IN (SELECT AA.id FROM building AA WHERE AA.built::timestamp(0) < TIMESTAMP '2012-06-05T00:00:00Z')"
+
+        String actual = filterEncoder.encode(filter, instanceContainer)
+
+        then:
+
+        actual == expected
+
+    }
+
+    def 'temporal operation, date'() {
+
+        given:
+        def instanceContainer = QuerySchemaFixtures.SIMPLE_DATE
+        def filter = CqlFilterExamples.EXAMPLE_12_date
+
+        when:
+        String expected = "A.id IN (SELECT AA.id FROM building AA WHERE AA.built::date < DATE '2012-06-05')"
 
         String actual = filterEncoder.encode(filter, instanceContainer)
 

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/QuerySchemaFixtures.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/QuerySchemaFixtures.groovy
@@ -236,7 +236,7 @@ class QuerySchemaFixtures {
                     .build())
             .build();
 
-    static SchemaSql SIMPLE_INSTANT = new ImmutableSchemaSql.Builder()
+    static SchemaSql SIMPLE_TIMESTAMP = new ImmutableSchemaSql.Builder()
             .name("building")
             .type(Type.OBJECT)
             .sortKey("id")
@@ -244,6 +244,18 @@ class QuerySchemaFixtures {
                     .name("built")
                     .sourcePath("built")
                     .type(Type.DATETIME)
+                    .parentPath(["building"])
+                    .build())
+            .build()
+
+    static SchemaSql SIMPLE_DATE = new ImmutableSchemaSql.Builder()
+            .name("building")
+            .type(Type.OBJECT)
+            .sortKey("id")
+            .addProperties(new ImmutableSchemaSql.Builder()
+                    .name("built")
+                    .sourcePath("built")
+                    .type(Type.DATE)
                     .parentPath(["building"])
                     .build())
             .build()


### PR DESCRIPTION
* use 'COALESCE' to map properties in intervals that are 'null' to +/- infinity
* prohibit mixing DATE and DATETIME in INTERVAL()
* treat DATE values as DATES and avoid casting to Instant
* fix issue in CQL Text writer with INTERVAL()