### PR TITLE
update casei(), accenti() and interval()

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlCoordinateChecker.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlCoordinateChecker.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 
 public class CqlCoordinateChecker extends CqlVisitorBase<Object> {
 
-    private static List<String> AXES = ImmutableList.of("first", "second", "third");
+    private static final List<String> AXES = ImmutableList.of("first", "second", "third");
 
     private final CrsInfo crsInfo;
     private final EpsgCrs filterCrs;

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorBase.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorBase.java
@@ -39,6 +39,15 @@ public class CqlVisitorBase<T> implements CqlVisitor<T> {
     public T visit(IsNull isNull, List<T> children) { return null; }
 
     @Override
+    public T visit(Casei casei, List<T> children) { return null; }
+
+    @Override
+    public T visit(Accenti accenti, List<T> children) { return null; }
+
+    @Override
+    public T visit(Interval interval, List<T> children) { return null; }
+
+    @Override
     public T visit(BinaryTemporalOperation temporalOperation, List<T> children) {
         return null;
     }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorCopy.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorCopy.java
@@ -89,6 +89,29 @@ public class CqlVisitorCopy implements CqlVisitor<CqlNode> {
     }
 
     @Override
+    public CqlNode visit(Casei casei, List<CqlNode> children) {
+        ImmutableCasei.Builder builder = new ImmutableCasei.Builder();
+        builder.value((Scalar) children.get(0));
+        return builder.build();
+    }
+
+    @Override
+    public CqlNode visit(Accenti accenti, List<CqlNode> children) {
+        ImmutableAccenti.Builder builder = new ImmutableAccenti.Builder();
+        builder.value((Scalar) children.get(0));
+        return builder.build();
+    }
+
+    @Override
+    public CqlNode visit(Interval interval, List<CqlNode> children) {
+        ImmutableInterval.Builder builder = new ImmutableInterval.Builder();
+        return builder.args(children.stream()
+                                .map(child -> (Operand) child)
+                                .collect(Collectors.toUnmodifiableList()))
+            .build();
+    }
+
+    @Override
     public CqlNode visit(Like like, List<CqlNode> children) {
         Like.Builder builder = new ImmutableLike.Builder();
 

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Accenti.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Accenti.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value;
+
+import java.util.Objects;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableAccenti.Builder.class)
+public interface Accenti extends CqlNode, Operand, Scalar {
+
+    String TYPE = "accenti";
+
+    @JsonProperty(TYPE)
+    Operand getValue();
+
+    static Accenti of(Operand value) {
+        return new ImmutableAccenti.Builder()
+                .value(value)
+                .build();
+    }
+
+    @Override
+    default <U> U accept(CqlVisitor<U> visitor) {
+
+        U value = getValue().accept(visitor);
+
+        return visitor.visit(this, Objects.nonNull(value) ? ImmutableList.of(value) : ImmutableList.of());
+    }
+}
+
+
+

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/BinaryTemporalOperation.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/BinaryTemporalOperation.java
@@ -78,14 +78,12 @@ public interface BinaryTemporalOperation extends BinaryOperation2<Temporal>, Cql
         BinaryOperation2.super.check();
         getArgs().forEach(operand -> {
             Preconditions.checkState(operand != null, "a temporal operation must have temporal operands, found null");
-            if (operand instanceof Function)
-                Preconditions.checkState(((Function) operand).isInterval(), "The arguments of %s must be an INTERVAL(). Found: a function '%s' of type '%s'.", getTemporalOperator().toString(), ((Function) operand).getName(), ((Function) operand).getType());
             if (INTERVAL_ONLY.contains(getTemporalOperator())) {
                 if (operand instanceof Property)
                     Preconditions.checkState(true, "The arguments of %s must be an INTERVAL(). Found: a property ('%s').", getTemporalOperator().toString(), ((Property) operand).getName());
                 if (operand instanceof TemporalLiteral)
-                    Preconditions.checkState( ((TemporalLiteral) operand).getType() == Interval.class ||
-                        (((TemporalLiteral) operand).getType() == Function.class && ((Function)((TemporalLiteral) operand).getValue()).isInterval()), "The arguments of %s must be an INTERVAL(). Found: a temporal literal '%s' of type '%s'.", getTemporalOperator().toString(), ((TemporalLiteral) operand).getValue(), ((TemporalLiteral) operand).getType());
+                    Preconditions.checkState(((TemporalLiteral) operand).getType() == Interval.class ||
+                        (((TemporalLiteral) operand).getType() == de.ii.xtraplatform.cql.domain.Interval.class), "The arguments of %s must be an INTERVAL(). Found: a temporal literal '%s' of type '%s'.", getTemporalOperator().toString(), ((TemporalLiteral) operand).getValue(), ((TemporalLiteral) operand).getType());
             }
         });
     }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Casei.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Casei.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.collect.ImmutableList;
+import org.immutables.value.Value;
+
+import java.util.Objects;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableCasei.Builder.class)
+public interface Casei extends CqlNode, Operand, Scalar {
+
+    String TYPE = "casei";
+
+    @JsonProperty(TYPE)
+    Operand getValue();
+
+    static Casei of(Operand value) {
+        return new ImmutableCasei.Builder()
+            .value(value)
+            .build();
+    }
+
+    @Override
+    default <U> U accept(CqlVisitor<U> visitor) {
+
+        U value = getValue().accept(visitor);
+
+        return visitor.visit(this, Objects.nonNull(value) ? ImmutableList.of(value) : ImmutableList.of());
+    }
+}
+
+
+

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/CqlVisitor.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/CqlVisitor.java
@@ -28,6 +28,12 @@ public interface CqlVisitor<T> {
             return visit((In) node, children);
         } else if (node instanceof IsNull) {
             return visit((IsNull) node, children);
+        } else if (node instanceof Casei) {
+            return visit((Casei) node, children);
+        } else if (node instanceof Accenti) {
+            return visit((Accenti) node, children);
+        } else if (node instanceof Interval) {
+            return visit((Interval) node, children);
         } else if (node instanceof BinaryScalarOperation) {
             return visit((BinaryScalarOperation) node, children);
         } else if (node instanceof BinaryTemporalOperation) {
@@ -84,6 +90,12 @@ public interface CqlVisitor<T> {
     T visit(In in, List<T> children);
 
     T visit(IsNull isNull, List<T> children);
+
+    T visit(Casei casei, List<T> children);
+
+    T visit(Accenti accenti, List<T> children);
+
+    T visit(Interval interval, List<T> children);
 
     T visit(BinaryTemporalOperation temporalOperation, List<T> children);
 

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Function.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Function.java
@@ -23,7 +23,7 @@ import org.threeten.extra.Interval;
 
 @Value.Immutable
 @JsonDeserialize(builder = ImmutableFunction.Builder.class)
-@JsonSerialize(using = Function.FunctionSerializer.class)
+@JsonSerialize(using = Function.Serializer.class)
 public interface Function extends CqlNode, Scalar, Temporal, Operand {
 
     String getName();
@@ -51,15 +51,14 @@ public interface Function extends CqlNode, Scalar, Temporal, Operand {
     @JsonIgnore
     @Value.Lazy
     default Class<?> getType() {
-        if (isAccenti() || isCasei() || isLower() || isUpper())
+        if (isLower() || isUpper())
             return String.class;
-        else if (isInterval())
-            return Interval.class;
         else if (isPosition())
             return Integer.class;
         return Object.class;
     }
 
+    /*
     @JsonIgnore
     @Value.Lazy
     default boolean isCasei() {
@@ -71,6 +70,13 @@ public interface Function extends CqlNode, Scalar, Temporal, Operand {
     default boolean isAccenti() {
         return "accenti".equalsIgnoreCase(getName());
     }
+
+    @JsonIgnore
+    @Value.Lazy
+    default boolean isInterval() {
+        return "interval".equalsIgnoreCase(getName());
+    }
+     */
 
     @JsonIgnore
     @Value.Lazy
@@ -90,24 +96,19 @@ public interface Function extends CqlNode, Scalar, Temporal, Operand {
         return "position".equalsIgnoreCase(getName());
     }
 
-    @JsonIgnore
-    @Value.Lazy
-    default boolean isInterval() {
-        return "interval".equalsIgnoreCase(getName());
-    }
+    class Serializer extends StdSerializer<Function> {
 
-    class FunctionSerializer extends StdSerializer<Function> {
-
-        protected FunctionSerializer() {
+        protected Serializer() {
             this(null);
         }
 
-        protected FunctionSerializer(Class<Function> t) {
+        protected Serializer(Class<Function> t) {
             super(t);
         }
 
         @Override
         public void serialize(Function value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            /*
             if (value.isCasei() || value.isAccenti()) {
                 gen.writeStartObject();
                 gen.writeFieldName(value.getName().toLowerCase());
@@ -134,6 +135,7 @@ public interface Function extends CqlNode, Scalar, Temporal, Operand {
                 gen.writeEndObject();
                 return;
             }
+             */
 
             gen.writeStartObject();
             gen.writeFieldName("function");

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/In.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/In.java
@@ -55,6 +55,14 @@ public interface In extends BinaryOperation2<Scalar>, CqlNode {
                                         .addArgs(ArrayLiteral.of(values))
                                         .build();
     }
+
+    static In of(Scalar leftOperand, List<Scalar> values) {
+        return new ImmutableIn.Builder()
+            .addArgs(leftOperand)
+            .addArgs(ArrayLiteral.of(values))
+            .build();
+    }
+
     static In ofFunction(Function function, List<Scalar> values) {
         return new ImmutableIn.Builder()
                 .addArgs(function)

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Interval.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Interval.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import org.immutables.value.Value;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Value.Immutable
+@JsonDeserialize(builder = ImmutableInterval.Builder.class)
+@JsonSerialize(using = Interval.Serializer.class)
+public interface Interval extends CqlNode, Temporal, Operand {
+
+    @JsonProperty("interval")
+    List<Operand> getArgs();
+
+    static Interval of(List<Operand> arguments) {
+        return new ImmutableInterval.Builder()
+                .args(arguments)
+                .build();
+    }
+
+    @Override
+    default <U> U accept(CqlVisitor<U> visitor) {
+
+        List<U> arguments = getArgs()
+                .stream()
+                .map(argument -> argument.accept(visitor))
+                .collect(Collectors.toList());
+
+        return visitor.visit(this, arguments);
+    }
+
+    class Serializer extends StdSerializer<Interval> {
+
+        protected Serializer() {
+            this(null);
+        }
+
+        protected Serializer(Class<Interval> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(Interval value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeStartObject();
+            gen.writeFieldName("interval");
+            gen.writeStartArray();
+            for (Operand operand : value.getArgs()) {
+                if (operand instanceof TemporalLiteral) {
+                    gen.writeString(String.format("%s", ((TemporalLiteral) operand).getValue().toString()));
+                } else {
+                    gen.writeObject(operand);
+                }
+            }
+            gen.writeEndArray();
+            gen.writeEndObject();
+        }
+    }
+}
+
+
+

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/IsNull.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/IsNull.java
@@ -35,6 +35,5 @@ public interface IsNull extends UnaryOperation<Scalar>, CqlNode {
   }
 
   abstract class Builder extends Operation.Builder<Scalar, IsNull> {
-
   }
 }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Operand.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Operand.java
@@ -88,9 +88,9 @@ public interface Operand extends CqlNode {
                 } else if (Objects.nonNull(node.get("type"))) {
                     return SpatialLiteral.of(oc.treeToValue(node, Geometry.class));
                 } else if (Objects.nonNull(node.get("casei"))) {
-                    return Function.of("CASEI", ImmutableList.of(getOperand(parser, node.get("casei"), parent)));
+                    return Casei.of(getOperand(parser, node.get("casei"), parent));
                 } else if (Objects.nonNull(node.get("accenti"))) {
-                    return Function.of("ACCENTI", ImmutableList.of(getOperand(parser, node.get("accenti"), parent)));
+                    return Accenti.of(getOperand(parser, node.get("accenti"), parent));
                 } else if (Objects.nonNull(node.get("op"))) {
                     return oc.treeToValue(node, Operation.class);
                 } else if (Objects.nonNull(node.get("function"))) {

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Temporal.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Temporal.java
@@ -7,5 +7,23 @@
  */
 package de.ii.xtraplatform.cql.domain;
 
+import com.google.common.collect.ImmutableList;
+
 public interface Temporal extends Scalar, Operand, CqlNode {
+
+  static Temporal intervalOf(Temporal op1, Temporal op2) {
+    // if at least one parameter is a property, we create a function, otherwise a fixed interval
+    if (op1 instanceof Property && op2 instanceof Property) {
+      return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((Property) op1, (Property) op2));
+    } else if (op1 instanceof Property &&  op2 instanceof TemporalLiteral) {
+      return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((Property) op1, (TemporalLiteral) op2));
+    } else if (op1 instanceof TemporalLiteral &&  op2 instanceof Property) {
+      return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((TemporalLiteral) op1, (Property) op2));
+    } else if (op1 instanceof TemporalLiteral &&  op2 instanceof TemporalLiteral) {
+      return TemporalLiteral.of((TemporalLiteral) op1, (TemporalLiteral) op2);
+    }
+
+    throw new IllegalStateException(
+        String.format("unsupported interval operands: %s, %s", op1.getClass(), op2.getClass()));
+  }
 }

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/TemporalLiteral.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/TemporalLiteral.java
@@ -106,11 +106,11 @@ public interface TemporalLiteral extends Temporal, Scalar, Literal, CqlNode {
     static Temporal interval(Temporal op1, Temporal op2) {
         // if at least one parameter is a property, we create a function, otherwise a fixed interval
         if (op1 instanceof Property && op2 instanceof Property) {
-            return Function.of("INTERVAL", ImmutableList.of((Property) op1, (Property) op2));
+            return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((Property) op1, (Property) op2));
         } else if (op1 instanceof Property &&  op2 instanceof TemporalLiteral) {
-            return Function.of("INTERVAL", ImmutableList.of((Property) op1, (TemporalLiteral) op2));
+            return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((Property) op1, (TemporalLiteral) op2));
         } else if (op1 instanceof TemporalLiteral &&  op2 instanceof Property) {
-            return Function.of("INTERVAL", ImmutableList.of((TemporalLiteral) op1, (Property) op2));
+            return de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of((TemporalLiteral) op1, (Property) op2));
         } else if (op1 instanceof TemporalLiteral &&  op2 instanceof TemporalLiteral) {
             return TemporalLiteral.of((TemporalLiteral) op1, (TemporalLiteral) op2);
         }
@@ -161,8 +161,8 @@ public interface TemporalLiteral extends Temporal, Scalar, Literal, CqlNode {
                 value(Interval.of(getStartInclusive(startInclusive.getValue()), getEndExclusive(endInclusive.getValue())));
                 type(Interval.class);
             } else {
-                value(Function.of("INTERVAL", ImmutableList.of(startInclusive, endInclusive)));
-                type(Function.class);
+                value(de.ii.xtraplatform.cql.domain.Interval.of(ImmutableList.of(startInclusive, endInclusive)));
+                type(de.ii.xtraplatform.cql.domain.Interval.class);
             }
         }
 
@@ -221,23 +221,21 @@ public interface TemporalLiteral extends Temporal, Scalar, Literal, CqlNode {
 
         @Override
         public void serialize(TemporalLiteral value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
-            if (value.getType().equals(Function.class)) {
-                Function f = (Function) value.getValue();
-                if (f.isInterval()) {
-                    gen.writeStartObject();
-                    gen.writeFieldName(f.getName().toLowerCase());
-                    gen.writeStartArray();
-                    for (Operand operand : f.getArgs()) {
-                        if (operand instanceof TemporalLiteral) {
-                            gen.writeString(String.format("%s", ((TemporalLiteral) operand).getValue().toString()));
-                        } else {
-                            gen.writeObject(operand);
-                        }
+            if (value.getType().equals(de.ii.xtraplatform.cql.domain.Interval.class)) {
+                de.ii.xtraplatform.cql.domain.Interval interval = (de.ii.xtraplatform.cql.domain.Interval) value.getValue();
+                gen.writeStartObject();
+                gen.writeFieldName("interval");
+                gen.writeStartArray();
+                for (Operand operand : interval.getArgs()) {
+                    if (operand instanceof TemporalLiteral) {
+                        gen.writeString(String.format("%s", ((TemporalLiteral) operand).getValue().toString()));
+                    } else {
+                        gen.writeObject(operand);
                     }
-                    gen.writeEndArray();
-                    gen.writeEndObject();
-                    return;
                 }
+                gen.writeEndArray();
+                gen.writeEndObject();
+                return;
             }
 
             // use default serializer

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlTextVisitor.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/infra/CqlTextVisitor.java
@@ -409,12 +409,12 @@ public class CqlTextVisitor extends CqlParserBaseVisitor<CqlNode> implements Cql
             Scalar scalar = (Scalar) ctx.characterExpression()
                 .accept(this);
 
-            return Function.of("CASEI", ImmutableList.of(scalar));
+            return Casei.of(scalar);
         } else if (Objects.nonNull(ctx.ACCENTI())) {
             Scalar scalar = (Scalar) ctx.characterExpression()
                 .accept(this);
 
-            return Function.of("ACCENTI", ImmutableList.of(scalar));
+            return Accenti.of(scalar);
         } else if (Objects.nonNull(ctx.LOWER())) {
             Scalar scalar = (Scalar) ctx.characterExpression()
                 .accept(this);

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlJsonSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlJsonSpec.groovy
@@ -1087,4 +1087,57 @@ class CqlJsonSpec extends Specification {
         JSONAssert.assertEquals(cqlJson, actual2, true)
     }
 
+    def 'UPPER'() {
+        given:
+        String cqlJson = """
+            {
+              "op": "in",
+              "args": [
+                { "function": { "name": "upper", "args": [ { "property": "road_class" } ] } },
+                [ "A", "B", "L", "K" ]
+              ]
+            }
+        """
+
+        when: 'reading json'
+        Cql2Expression actual = cql.read(cqlJson, Cql.Format.JSON)
+
+        then:
+        actual == CqlFilterExamples.EXAMPLE_UPPER
+
+        and:
+
+        when: 'writing json'
+        String actual2 = cql.write(CqlFilterExamples.EXAMPLE_UPPER, Cql.Format.JSON)
+
+        then:
+        JSONAssert.assertEquals(cqlJson, actual2, true)
+    }
+
+    def 'LOWER'() {
+        given:
+        String cqlJson = """
+            {
+              "op": "in",
+              "args": [
+                { "function": { "name": "lower", "args": [ { "property": "road_class" } ] } },
+                [ "a", "b", "l", "k" ]
+              ]
+            }
+        """
+
+        when: 'reading json'
+        Cql2Expression actual = cql.read(cqlJson, Cql.Format.JSON)
+
+        then:
+        actual == CqlFilterExamples.EXAMPLE_LOWER
+
+        and:
+
+        when: 'writing json'
+        String actual2 = cql.write(CqlFilterExamples.EXAMPLE_LOWER, Cql.Format.JSON)
+
+        then:
+        JSONAssert.assertEquals(cqlJson, actual2, true)
+    }
 }

--- a/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
+++ b/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
@@ -157,9 +157,9 @@ public class CqlFilterExamples {
 
     public static final Cql2Expression EXAMPLE_25 = TDuring.of(Property.of("updated"), Objects.requireNonNull(TemporalLiteral.of("2017-06-10T07:30:00Z", "2017-06-11T10:30:00Z")));
     public static final Cql2Expression EXAMPLE_25b = TDuring.of(Property.of("updated"), Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "2017-06-11")));
-    public static final Cql2Expression EXAMPLE_25x = TIntersects.of(Function.of("INTERVAL",ImmutableList.of(Property.of("start"),Property.of("end"))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10T07:30:00Z", "2017-06-11T10:30:00Z")));
-    public static final Cql2Expression EXAMPLE_25y = TIntersects.of(Function.of("INTERVAL",ImmutableList.of(Property.of("start"),Property.of("end"))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "2017-06-11")));
-    public static final Cql2Expression EXAMPLE_25z = TIntersects.of(Function.of("INTERVAL",ImmutableList.of(Property.of("start"),TemporalLiteral.of(".."))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "..")));
+    public static final Cql2Expression EXAMPLE_25x = TIntersects.of(Interval.of(ImmutableList.of(Property.of("start"),Property.of("end"))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10T07:30:00Z", "2017-06-11T10:30:00Z")));
+    public static final Cql2Expression EXAMPLE_25y = TIntersects.of(Interval.of(ImmutableList.of(Property.of("start"),Property.of("end"))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "2017-06-11")));
+    public static final Cql2Expression EXAMPLE_25z = TIntersects.of(Interval.of(ImmutableList.of(Property.of("start"),TemporalLiteral.of(".."))), Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "..")));
     public static final CqlFilter EXAMPLE_25_OLD = CqlFilter.of(TemporalOperation.of(TemporalOperator.T_DURING, "updated",
         Objects.requireNonNull(TemporalLiteral.of("2017-06-10", "2017-06-11"))));
 
@@ -241,7 +241,7 @@ public class CqlFilterExamples {
 
     public static final CqlFilter EXAMPLE_TDISJOINT = CqlFilter.of(TemporalOperation.of(TemporalOperator.T_DISJOINT,"event_date", TemporalLiteral.of("1969-07-16T05:32:00Z","1969-07-24T16:50:35Z")));
 
-    public static final Cql2Expression EXAMPLE_TINTERSECTS = TIntersects.of(Property.of("event_date"), Function.of("INTERVAL", ImmutableList.of(Property.of("startDate"), Property.of("endDate"))));
+    public static final Cql2Expression EXAMPLE_TINTERSECTS = TIntersects.of(Property.of("event_date"), Interval.of(ImmutableList.of(Property.of("startDate"), Property.of("endDate"))));
 
     public static final CqlFilter EXAMPLE_SDISJOINT = CqlFilter.of(SpatialOperation.of(SpatialOperator.S_DISJOINT, "geometry", SpatialLiteral.of(Geometry.Envelope.of(-118.0, 33.8, -117.9, 34.0))));
 
@@ -300,29 +300,37 @@ public class CqlFilterExamples {
 
     public static final Cql2Expression EXAMPLE_KEYWORD = Gt.of(ImmutableList.of(Property.of("root.date"), TemporalLiteral.of("2022-04-17")));
 
-    public static final Cql2Expression EXAMPLE_CASEI = In.ofFunction(
-            Function.of("CASEI", ImmutableList.of(Property.of("road_class"))),
+    public static final Cql2Expression EXAMPLE_CASEI = In.of(
+            Casei.of(Property.of("road_class")),
             ImmutableList.of(
-                    Function.of("CASEI", ImmutableList.of(ScalarLiteral.of("Οδος"))),
-                    Function.of("CASEI", ImmutableList.of(ScalarLiteral.of("Straße")))
+                    Casei.of(ScalarLiteral.of("Οδος")),
+                    Casei.of(ScalarLiteral.of("Straße"))
     ));
-    public static final CqlFilter EXAMPLE_CASEI_OLD = CqlFilter.of(In.ofFunction(
-        Function.of("CASEI", ImmutableList.of(Property.of("road_class"))),
+    public static final CqlFilter EXAMPLE_CASEI_OLD = CqlFilter.of(In.of(
+        Casei.of(Property.of("road_class")),
         ImmutableList.of(
-            Function.of("CASEI", ImmutableList.of(ScalarLiteral.of("Οδος"))),
-            Function.of("CASEI", ImmutableList.of(ScalarLiteral.of("Straße"))))
-    ));
+            Casei.of(ScalarLiteral.of("Οδος")),
+            Casei.of(ScalarLiteral.of("Straße"))
+    )));
 
-    public static final Cql2Expression EXAMPLE_ACCENTI = In.ofFunction(
-            Function.of("ACCENTI", ImmutableList.of(Property.of("road_class"))),
+    public static final Cql2Expression EXAMPLE_ACCENTI = In.of(
+            Accenti.of(Property.of("road_class")),
             ImmutableList.of(
-                    Function.of("ACCENTI", ImmutableList.of(ScalarLiteral.of("Οδος"))),
-                    Function.of("ACCENTI", ImmutableList.of(ScalarLiteral.of("Straße")))
+                Accenti.of(ScalarLiteral.of("Οδος")),
+                Accenti.of(ScalarLiteral.of("Straße"))
     ));
-    public static final CqlFilter EXAMPLE_ACCENTI_OLD = CqlFilter.of(In.ofFunction(
-        Function.of("ACCENTI", ImmutableList.of(Property.of("road_class"))),
+    public static final CqlFilter EXAMPLE_ACCENTI_OLD = CqlFilter.of(In.of(
+        Accenti.of(Property.of("road_class")),
         ImmutableList.of(
-            Function.of("ACCENTI", ImmutableList.of(ScalarLiteral.of("Οδος"))),
-            Function.of("ACCENTI", ImmutableList.of(ScalarLiteral.of("Straße"))))
-    ));
+            Accenti.of(ScalarLiteral.of("Οδος")),
+            Accenti.of(ScalarLiteral.of("Straße"))
+    )));
+
+    public static final Cql2Expression EXAMPLE_UPPER = In.ofFunction(
+        Function.of("upper", ImmutableList.of(Property.of("road_class"))),
+        ImmutableList.of(ScalarLiteral.of("A"), ScalarLiteral.of("B"), ScalarLiteral.of("L"), ScalarLiteral.of("K")));
+    public static final Cql2Expression EXAMPLE_LOWER = In.ofFunction(
+        Function.of("lower", ImmutableList.of(Property.of("road_class"))),
+        ImmutableList.of(ScalarLiteral.of("a"), ScalarLiteral.of("b"), ScalarLiteral.of("l"), ScalarLiteral.of("k")));
+
 }

--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/app/FilterEncoderWfs.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/app/FilterEncoderWfs.java
@@ -11,20 +11,7 @@ import static de.ii.xtraplatform.cql.domain.In.ID_PLACEHOLDER;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Doubles;
-import de.ii.xtraplatform.cql.domain.ArrayLiteral;
-import de.ii.xtraplatform.cql.domain.Between;
-import de.ii.xtraplatform.cql.domain.BinaryArrayOperation;
-import de.ii.xtraplatform.cql.domain.BinaryScalarOperation;
-import de.ii.xtraplatform.cql.domain.BinarySpatialOperation;
-import de.ii.xtraplatform.cql.domain.BinaryTemporalOperation;
-import de.ii.xtraplatform.cql.domain.BooleanValue2;
-import de.ii.xtraplatform.cql.domain.Cql;
-import de.ii.xtraplatform.cql.domain.Cql2Expression;
-import de.ii.xtraplatform.cql.domain.CqlNode;
-import de.ii.xtraplatform.cql.domain.CqlPredicate;
-import de.ii.xtraplatform.cql.domain.CqlVisitor;
-import de.ii.xtraplatform.cql.domain.Eq;
-import de.ii.xtraplatform.cql.domain.Function;
+import de.ii.xtraplatform.cql.domain.*;
 import de.ii.xtraplatform.cql.domain.Geometry.Coordinate;
 import de.ii.xtraplatform.cql.domain.Geometry.Envelope;
 import de.ii.xtraplatform.cql.domain.Geometry.LineString;
@@ -33,19 +20,6 @@ import de.ii.xtraplatform.cql.domain.Geometry.MultiPoint;
 import de.ii.xtraplatform.cql.domain.Geometry.MultiPolygon;
 import de.ii.xtraplatform.cql.domain.Geometry.Point;
 import de.ii.xtraplatform.cql.domain.Geometry.Polygon;
-import de.ii.xtraplatform.cql.domain.Gt;
-import de.ii.xtraplatform.cql.domain.In;
-import de.ii.xtraplatform.cql.domain.IsNull;
-import de.ii.xtraplatform.cql.domain.Like;
-import de.ii.xtraplatform.cql.domain.LogicalOperation;
-import de.ii.xtraplatform.cql.domain.Lt;
-import de.ii.xtraplatform.cql.domain.Not;
-import de.ii.xtraplatform.cql.domain.Or;
-import de.ii.xtraplatform.cql.domain.Property;
-import de.ii.xtraplatform.cql.domain.ScalarLiteral;
-import de.ii.xtraplatform.cql.domain.SpatialLiteral;
-import de.ii.xtraplatform.cql.domain.SpatialOperator;
-import de.ii.xtraplatform.cql.domain.TemporalLiteral;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.CrsTransformer;
 import de.ii.xtraplatform.crs.domain.CrsTransformerFactory;
@@ -219,6 +193,24 @@ public class FilterEncoderWfs {
     @Override
     public FesExpression visit(IsNull isNull, List<FesExpression> children) {
       throw new IllegalArgumentException("IS NULL predicates are not supported in filter expressions for WFS feature providers.");
+    }
+
+    @Override
+    public FesExpression visit(Casei casei, List<FesExpression> children) {
+      throw new IllegalArgumentException(
+          "Casei() is not supported in filter expressions for WFS feature providers.");
+    }
+
+    @Override
+    public FesExpression visit(Accenti accenti, List<FesExpression> children) {
+      throw new IllegalArgumentException(
+          "Accenti() is not supported in filter expressions for WFS feature providers.");
+    }
+
+    @Override
+    public FesExpression visit(de.ii.xtraplatform.cql.domain.Interval interval, List<FesExpression> children) {
+      throw new IllegalArgumentException(
+          "Non-trivial intervals are not supported in filter expressions for WFS feature providers.");
     }
 
     @Override


### PR DESCRIPTION
casei(), accenti() and interval()  are no longer functions in the CQL2 grammar, but they still were in the internal representation, which required special treatment, e.g., in the JSON serializer. They have been moved to separate node subtypes.