### PR TITLE
update crs tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'de.interactive_instruments.xtraplatform-layer' version '4.3.11'
+    id 'de.interactive_instruments.xtraplatform-layer' version '4.4.1'
     id "com.diffplug.spotless" version "6.7.2" apply false
 }
 


### PR DESCRIPTION
change tests to support also ARM processors which give slightly different floating point values compared to Intel processors; uses 1e-6 for meter values and 1e-11 for degrees.