### PR TITLE
handle properties with the same path

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTokenTransformerSorting.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTokenTransformerSorting.java
@@ -37,6 +37,7 @@ public class FeatureTokenTransformerSorting extends FeatureTokenTransformer {
   private final Map<List<String>, Integer> rearrange;
   private final Queue<Integer> indexQueue;
   private final Queue<List<String>> pathQueue;
+  private final Queue<Integer> schemaIndexQueue;
   private final Queue<List<Integer>> indexesQueue;
   private final Queue<String> valueQueue;
   private final Queue<Optional<SimpleFeatureGeometry>> geoTypeQueue;
@@ -54,6 +55,7 @@ public class FeatureTokenTransformerSorting extends FeatureTokenTransformer {
     this.rearrange = new LinkedHashMap<>();
     this.indexQueue = new LinkedList<>();
     this.pathQueue = new LinkedList<>();
+    this.schemaIndexQueue = new LinkedList<>();
     this.indexesQueue = new LinkedList<>();
     this.valueQueue = new LinkedList<>();
     this.geoTypeQueue = new LinkedList<>();
@@ -199,6 +201,7 @@ public class FeatureTokenTransformerSorting extends FeatureTokenTransformer {
     indexQueue.add(index);
     tokenQueue.add(token);
     pathQueue.add(context.path());
+    schemaIndexQueue.add(context.schemaIndex());
     indexesQueue.add(new ArrayList<>(context.indexes()));
     valueQueue.add(context.value());
     geoTypeQueue.add(context.geometryType());
@@ -225,6 +228,7 @@ public class FeatureTokenTransformerSorting extends FeatureTokenTransformer {
       FeatureTokenType token = tokenQueue.remove();
 
       context.pathTracker().track(pathQueue.remove());
+      context.setSchemaIndex(schemaIndexQueue.remove());
       context.setIndexes(indexesQueue.remove());
       context.setValue(valueQueue.remove());
       context.setGeometryType(geoTypeQueue.remove());


### PR DESCRIPTION
If the provider schema contains links between features, these are often expressed as Link objects like this:

```yaml
      property:
        type: OBJECT
        objectType: Link
        properties:
          title:
            sourcePath: foreign_key
            type: STRING
          href:
            sourcePath: foreign_key
            type: STRING
            transformations:
            - stringFormat: '{{serviceUrl}}/collections/target/items/{{value}}'
```

I had cases where I would get the following in GML:

```xml
<property 
 xlink:href="http://localhost:7080/rest/services/api/collections/target/items/1" 
 xlink:href="http://localhost:7080/rest/services/api/collections/target/items/1"/>
```

and in GeoJSON:

```json
"property": {
  "href": "http://localhost:7080/rest/services/api/collections/target/items/1"
}
```

The problem seems to be in `FeatureTokenTransformerSorting` where only the `path` is buffered, but not the `schemaIndex` of the value. 

This change also buffers the schema index, so that this information can be restored, when the buffer is emptied.