### PR TITLE
reactivate hitsOnly for SQL providers

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureQueryEncoderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureQueryEncoderSql.java
@@ -118,7 +118,10 @@ class FeatureQueryEncoderSql implements FeatureQueryEncoder<SqlQueries, SqlQuery
 
     List<SortKey> sortKeys = transformSortKeys(featureQuery.getSortKeys(), mainTable);
 
-    return new ImmutableSqlQueryOptions.Builder().customSortKeys(sortKeys).build();
+    return new ImmutableSqlQueryOptions.Builder()
+        .customSortKeys(sortKeys)
+        .isHitsOnly(featureQuery.hitsOnly())
+        .build();
   }
 
   private List<SortKey> transformSortKeys(

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlConnector.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlConnector.java
@@ -68,6 +68,14 @@ public interface SqlConnector
 
     Reactive.Source<SqlRowMeta> metaResult1 = getMetaResult(metaQuery, options);
 
+    if (options.isHitsOnly()) {
+      return metaResult1
+          .via(
+              Reactive.Transformer.flatMap(
+                  metaResult -> Reactive.Source.single((SqlRow) metaResult)))
+          .mapError(PSQL_CONTEXT);
+    }
+
     // TODO: multiple main tables
     FeatureStoreInstanceContainer mainTable = query.getInstanceContainers().get(0);
     List<FeatureStoreAttributesContainer> attributesContainers =

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlQueryOptions.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlQueryOptions.java
@@ -49,6 +49,11 @@ public interface SqlQueryOptions extends FeatureProviderConnector.QueryOptions {
   List<Class<?>> getCustomColumnTypes();
 
   @Value.Default
+  default boolean isHitsOnly() {
+    return false;
+  }
+
+  @Value.Default
   default int getContainerPriority() {
     return 0;
   }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/AbstractFeatureProvider.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/AbstractFeatureProvider.java
@@ -301,7 +301,8 @@ public abstract class AbstractFeatureProvider<T, U, V extends FeatureProviderCon
 
     public FeatureStreamImpl(FeatureQuery query, boolean doTransform) {
       this.query = query;
-      this.doTransform = doTransform;
+      // skip property transformations, if no features are returned
+      this.doTransform = doTransform && !query.hitsOnly();
     }
 
     public FeatureStreamImpl(FeatureQuery query) {


### PR DESCRIPTION
see https://github.com/interactive-instruments/ldproxy/issues/706

This addresses the SQL providers only, not the WFS providers.