### PR TITLE
handle degenerate bbox

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorMapEnvelopes.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorMapEnvelopes.java
@@ -10,7 +10,10 @@ package de.ii.xtraplatform.cql.app;
 import com.google.common.collect.ImmutableList;
 import de.ii.xtraplatform.cql.domain.CqlNode;
 import de.ii.xtraplatform.cql.domain.Geometry;
+import de.ii.xtraplatform.cql.domain.Geometry.Coordinate;
+import de.ii.xtraplatform.cql.domain.ImmutableLineString;
 import de.ii.xtraplatform.cql.domain.ImmutableMultiPolygon;
+import de.ii.xtraplatform.cql.domain.ImmutablePoint;
 import de.ii.xtraplatform.cql.domain.ImmutablePolygon;
 import de.ii.xtraplatform.cql.domain.SpatialLiteral;
 import de.ii.xtraplatform.crs.domain.CrsInfo;
@@ -40,10 +43,24 @@ public class CqlVisitorMapEnvelopes extends CqlVisitorCopy {
   @Override
   public CqlNode visit(Geometry.Envelope envelope, List<CqlNode> children) {
     List<Double> c = envelope.getCoordinates();
+    EpsgCrs crs = envelope.getCrs().orElse(OgcCrs.CRS84);
+
+    // if the bbox is degenerate (vertical or horizontal line, point), reduce
+    // the geometry
+    if (c.get(0).equals(c.get(2)) && c.get(1).equals(c.get(3))) {
+      return new ImmutablePoint.Builder()
+          .addCoordinates(Coordinate.of(c.get(0), c.get(1)))
+          .crs(crs)
+          .build();
+    } else if (c.get(0).equals(c.get(2)) || c.get(1).equals(c.get(3))) {
+      return new ImmutableLineString.Builder()
+          .addCoordinates(Coordinate.of(c.get(0), c.get(1)), Coordinate.of(c.get(2), c.get(3)))
+          .crs(crs)
+          .build();
+    }
 
     // if the bbox crosses the antimeridian, we create a MultiPolygon with a polygon
     // on each side of the antimeridian
-    EpsgCrs crs = envelope.getCrs().orElse(OgcCrs.CRS84);
     if (Objects.nonNull(crsInfo)) {
       int axisWithWraparaound = crsInfo.getAxisWithWraparound(crs).orElse(-1);
       if (axisWithWraparaound == 0 && c.get(0) > c.get(2)) {


### PR DESCRIPTION
A ST_Intersects() with a bounding box / polygon that is a point or a horizontal/vertical line results in an empty results (since it is an invalid polygon). Reduce an envelope that is a point to a point and reduce an envelope that is a horizontal/vertical line to a line string.

Closes https://github.com/interactive-instruments/ldproxy/issues/709