### PR TITLE
fix issue with filter expression with logical operator in a join value query

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
@@ -237,7 +237,9 @@ public class SqlQueryTemplatesDeriver
               mainTableName,
               aliasesNested.get(0),
               mainTableSortKey,
-              where.replace("(A.", "(" + aliasesNested.get(0) + "."),
+              where
+                  .replace("(A.", "(" + aliasesNested.get(0) + ".")
+                  .replace(" A.", " " + aliasesNested.get(0) + "."),
               orderBy,
               pagingClause.get());
 

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -7,17 +7,19 @@
  */
 package de.ii.xtraplatform.features.sql.app
 
+import com.google.common.collect.ImmutableMap
 import de.ii.xtraplatform.cql.app.CqlImpl
+import de.ii.xtraplatform.cql.domain.And
 import de.ii.xtraplatform.cql.domain.Cql2Expression
 import de.ii.xtraplatform.cql.domain.Eq
 import de.ii.xtraplatform.cql.domain.Property
 import de.ii.xtraplatform.cql.domain.ScalarLiteral
 import de.ii.xtraplatform.crs.domain.OgcCrs
-import de.ii.xtraplatform.features.sql.domain.SqlDialectPostGis
 import de.ii.xtraplatform.features.domain.SortKey
+import de.ii.xtraplatform.features.domain.Tuple
+import de.ii.xtraplatform.features.sql.domain.SqlDialectPostGis
 import spock.lang.Shared
 import spock.lang.Specification
-import de.ii.xtraplatform.features.domain.Tuple;
 
 class SqlQueryTemplatesDeriverSpec extends Specification {
 
@@ -65,29 +67,29 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
 
         where:
 
-        casename                             | deriver | limit | offset | sortBy                  | filter                                                     | source                                                  || expected
-        "value array"                        | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.VALUE_ARRAY                         || SqlQueryTemplatesFixtures.VALUE_ARRAY
-        "object array"                       | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY
-        "merge"                              | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.MERGE                               || SqlQueryTemplatesFixtures.MERGE
-        "self joins"                         | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.SELF_JOINS                          || SqlQueryTemplatesFixtures.SELF_JOINS
-        "self joins with filters"            | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.SELF_JOINS_FILTER                   || SqlQueryTemplatesFixtures.SELF_JOINS_FILTER
-        "self join with nested duplicate"    | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.SELF_JOIN_NESTED_DUPLICATE          || SqlQueryTemplatesFixtures.SELF_JOIN_NESTED_DUPLICATE
-        "object without sourcePath"          | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.OBJECT_WITHOUT_SOURCE_PATH          || SqlQueryTemplatesFixtures.OBJECT_WITHOUT_SOURCE_PATH
-        "paging"                             | td      | 10    | 10     | []                      | null                                                       | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_PAGING
-        "sortBy"                             | td      | 0     | 0      | [SortKey.of("created")] | null                                                       | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY
+        casename                             | deriver | limit | offset | sortBy                  | filter                                                                                                                      | source                                                  || expected
+        "value array"                        | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.VALUE_ARRAY                         || SqlQueryTemplatesFixtures.VALUE_ARRAY
+        "object array"                       | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY
+        "merge"                              | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.MERGE                               || SqlQueryTemplatesFixtures.MERGE
+        "self joins"                         | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOINS                          || SqlQueryTemplatesFixtures.SELF_JOINS
+        "self joins with filters"            | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOINS_FILTER                   || SqlQueryTemplatesFixtures.SELF_JOINS_FILTER
+        "self join with nested duplicate"    | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOIN_NESTED_DUPLICATE          || SqlQueryTemplatesFixtures.SELF_JOIN_NESTED_DUPLICATE
+        "object without sourcePath"          | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_WITHOUT_SOURCE_PATH          || SqlQueryTemplatesFixtures.OBJECT_WITHOUT_SOURCE_PATH
+        "paging"                             | td      | 10    | 10     | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_PAGING
+        "sortBy"                             | td      | 0     | 0      | [SortKey.of("created")] | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY
         "sortBy + filter"                    | td      | 0     | 0      | [SortKey.of("created")] | Eq.of(Property.of("task.title"), ScalarLiteral.of("foo")) | QuerySchemaFixtures.OBJECT_ARRAY || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_FILTER
-        "sortBy + paging"                    | td      | 10    | 10     | [SortKey.of("created")] | null                                                       | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING
-        "sortBy + paging + filter"           | td      | 10    | 10     | [SortKey.of("created")] | Eq.of(Property.of("task.title"), ScalarLiteral.of("foo")) | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING_FILTER
-        "property with multiple sourcePaths" | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS || SqlQueryTemplatesFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS
-        "nested joins"                       | td      | 0     | 0      | []                      | null                                                       | QuerySchemaFixtures.NESTED_JOINS                        || SqlQueryTemplatesFixtures.NESTED_JOINS
+        "sortBy + paging"                    | td      | 10    | 10     | [SortKey.of("created")] | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING
+        "sortBy + paging + filter"           | td      | 10    | 10     | [SortKey.of("created")] | And.of(Eq.of(Property.of("task.title"), ScalarLiteral.of("foo")), Eq.of(Property.of("task.href"), ScalarLiteral.of("bar"))) | QuerySchemaFixtures.OBJECT_ARRAY || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING_FILTER
+        "property with multiple sourcePaths" | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS || SqlQueryTemplatesFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS
+        "nested joins"                       | td      | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.NESTED_JOINS                        || SqlQueryTemplatesFixtures.NESTED_JOINS
     }
 
     static String meta(SqlQueryTemplates templates, List<SortKey> sortBy, Optional<Cql2Expression> userFilter) {
-        return templates.getMetaQueryTemplate().generateMetaQuery(10, 10, 0, sortBy, userFilter, com.google.common.collect.ImmutableMap.of(), false, true)
+        return templates.getMetaQueryTemplate().generateMetaQuery(10, 10, 0, sortBy, userFilter, ImmutableMap.of(), false, true)
     }
 
     static List<String> values(SqlQueryTemplates templates, int limit, int offset, List<SortKey> sortBy, Cql2Expression filter) {
-        return templates.getValueQueryTemplates().collect { it.generateValueQuery(limit, offset, sortBy, Optional.ofNullable(filter), limit == 0 ? Optional.<Tuple<Object, Object>> empty() : Optional.of(Tuple.of(offset, offset + limit - 1)), com.google.common.collect.ImmutableMap.of()) }
+        return templates.getValueQueryTemplates().collect { it.generateValueQuery(limit, offset, sortBy, Optional.ofNullable(filter), limit == 0 ? Optional.<Tuple<Object, Object>> empty() : Optional.of(Tuple.of(offset, offset + limit - 1)), ImmutableMap.of()) }
     }
 
 }

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesFixtures.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesFixtures.groovy
@@ -106,8 +106,8 @@ class SqlQueryTemplatesFixtures {
     ]
 
     static List<String> OBJECT_ARRAY_SORTBY_PAGING_FILTER = [
-            "SELECT A.created AS CSKEY_0, A.id AS SKEY, A.id FROM explorationsite A WHERE (A.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.projectname = 'foo')) ORDER BY 1,2 LIMIT 10 OFFSET 10",
-            "SELECT A.created AS CSKEY_0, A.id AS SKEY, C.id AS SKEY_1, C.projectname, C.id FROM explorationsite A JOIN explorationsite_task B ON (A.id=B.explorationsite_fk) JOIN task C ON (B.task_fk=C.id) WHERE (A.id IN (SELECT AAA.id FROM explorationsite AAA WHERE (AAA.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.projectname = 'foo')) ORDER BY AAA.created,AAA.id LIMIT 10 OFFSET 10)) ORDER BY 1,2,3"
+            "SELECT A.created AS CSKEY_0, A.id AS SKEY, A.id FROM explorationsite A WHERE ((A.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.projectname = 'foo') AND A.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.id = 'bar'))) ORDER BY 1,2 LIMIT 10 OFFSET 10",
+            "SELECT A.created AS CSKEY_0, A.id AS SKEY, C.id AS SKEY_1, C.projectname, C.id FROM explorationsite A JOIN explorationsite_task B ON (A.id=B.explorationsite_fk) JOIN task C ON (B.task_fk=C.id) WHERE (A.id IN (SELECT AAA.id FROM explorationsite AAA WHERE ((AAA.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.projectname = 'foo') AND AAA.id IN (SELECT AA.id FROM explorationsite AA JOIN explorationsite_task AB ON (AA.id=AB.explorationsite_fk) JOIN task AC ON (AB.task_fk=AC.id) WHERE AC.id = 'bar'))) ORDER BY AAA.created,AAA.id LIMIT 10 OFFSET 10)) ORDER BY 1,2,3"
     ]
 
     static List<String> PROPERTY_WITH_MULTIPLE_SOURCE_PATHS = [


### PR DESCRIPTION
The stored query https://t18.ldproxy.net/d103_airports/search/surface-areas?type=PARKING&airports=JFK,EWR,LGA&offset=10&f=json matches 13 apronelement features, but more features were returned. The additional features were in GeoJSON `{"type": "Feature", "properties": null, "geometry": null}`.

The reason was the following value query for the join to apron. The following SQL query was generated:

`A.airport AS CSKEY_0, A.ogc_fid AS SKEY, B.ogc_fid AS SKEY_1, B.name, B.ogc_fid FROM apronelement A JOIN apron B ON (A.associatedapron=B.gml_id) WHERE (A.ogc_fid IN (SELECT AAA.ogc_fid FROM apronelement AAA WHERE ((AAA.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.aixmtype = 'PARKING') AND A.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.airport IN ('JFK','EWR','LGA')))) ORDER BY AAA.airport,AAA.ogc_fid LIMIT 10 OFFSET 10)) ORDER BY 1,2,3`

The problem is with 

`SELECT AAA.ogc_fid FROM apronelement AAA WHERE ((AAA.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.aixmtype = 'PARKING') AND A.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.airport IN ('JFK','EWR','LGA'))))`

The WHERE statement was originally 

`(A.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.aixmtype = 'PARKING') AND A.ogc_fid IN (SELECT AA.ogc_fid FROM apronelement AA WHERE AA.airport IN ('JFK','EWR','LGA'))`

and only the first `A.ogc_fid` was changed to `AAA.ogc_fid`, not the second one. A blank should also match as a character before the sort key in addition to an opening parenthesis.
