### PR TITLE
sql spatial operators for 3d

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ layer {
 
 dependencies {
     layers group: 'de.interactive_instruments', name: 'xtraplatform-core', version: '5.2.0-SNAPSHOT'
-    layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.1.0-${platform}"
+    layers group: 'de.interactive_instruments', name: 'xtraplatform-native', version: "2.2.0-${platform}-SNAPSHOT"
 
     modules subprojects
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/QuerySchemaDeriver.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/QuerySchemaDeriver.java
@@ -342,7 +342,8 @@ public class QuerySchemaDeriver implements MappedSchemaDeriver<SchemaSql, SqlPat
             .properties(newVisitedProperties)
             .constantValue(targetSchema.getConstantValue())
             .forcePolygonCCW(
-                targetSchema.isForcePolygonCCW() ? Optional.empty() : Optional.of(false));
+                targetSchema.isForcePolygonCCW() ? Optional.empty() : Optional.of(false))
+            .constraints(targetSchema.getConstraints());
 
     if (targetSchema.isObject()) {
       if (targetSchema.getProperties().stream()

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
@@ -53,8 +53,10 @@ public interface SqlDialect {
 
   List<String> getSystemTables();
 
-  default String getSpatialOperator(SpatialOperator spatialOperator) {
-    return SPATIAL_OPERATORS.get(spatialOperator);
+  default String getSpatialOperator(SpatialOperator spatialOperator, boolean is3d) {
+    return is3d && SPATIAL_OPERATORS_3D.containsKey(spatialOperator)
+        ? SPATIAL_OPERATORS_3D.get(spatialOperator)
+        : SPATIAL_OPERATORS.get(spatialOperator);
   }
 
   default String getTemporalOperator(TemporalOperator temporalOperator) {
@@ -87,4 +89,7 @@ public interface SqlDialect {
           .put(SpatialOperator.S_INTERSECTS, "ST_Intersects")
           .put(SpatialOperator.S_CONTAINS, "ST_Contains")
           .build();
+
+  Map<SpatialOperator, String> SPATIAL_OPERATORS_3D =
+      new ImmutableMap.Builder<SpatialOperator, String>().build();
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPostGis.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPostGis.java
@@ -10,6 +10,7 @@ package de.ii.xtraplatform.features.sql.domain;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import de.ii.xtraplatform.cql.domain.SpatialOperator;
 import de.ii.xtraplatform.cql.domain.TemporalOperator;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
@@ -27,6 +28,10 @@ public class SqlDialectPostGis implements SqlDialect {
 
   private static final Splitter BBOX_SPLITTER =
       Splitter.onPattern("[(), ]").omitEmptyStrings().trimResults();
+  private static final Map<SpatialOperator, String> SPATIAL_OPERATORS_3D =
+      new ImmutableMap.Builder<SpatialOperator, String>()
+          .put(SpatialOperator.S_INTERSECTS, "ST_3DIntersects")
+          .build();
   public static final Map<TemporalOperator, String> TEMPORAL_OPERATORS =
       new ImmutableMap.Builder<TemporalOperator, String>()
           .put(
@@ -97,6 +102,13 @@ public class SqlDialectPostGis implements SqlDialect {
     }
     Instant parsedEnd = parser.parse(end, Instant::from);
     return Optional.of(Interval.of(parsedStart, parsedEnd));
+  }
+
+  @Override
+  public String getSpatialOperator(SpatialOperator spatialOperator, boolean is3d) {
+    return is3d && SPATIAL_OPERATORS_3D.containsKey(spatialOperator)
+        ? SPATIAL_OPERATORS_3D.get(spatialOperator)
+        : SqlDialect.super.getSpatialOperator(spatialOperator, is3d);
   }
 
   @Override

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaBase.java
@@ -340,6 +340,17 @@ public interface SchemaBase<T extends SchemaBase<T>> {
     return getConstraints().filter(SchemaConstraints::isRequired).isPresent();
   }
 
+  @JsonIgnore
+  @Value.Derived
+  @Value.Auxiliary
+  default boolean is3dGeometry() {
+    return getGeometryType().isPresent()
+        && getGeometryType().get() == SimpleFeatureGeometry.MULTI_POLYGON
+        && getConstraints().isPresent()
+        && getConstraints().get().isClosed()
+        && getConstraints().get().isComposite();
+  }
+
   default <U> U accept(SchemaVisitor<T, U> visitor) {
     return visitor.visit(
         (T) this,


### PR DESCRIPTION
- introduces a schema-based detection for 3d geometries
- enables usage of different spatial operators for 3d geometries
- currently the only case is to use `ST_3DIntersects` for polyhedral surfaces (composite and closed MultiPolygon) with PostGIS