### PR TITLE
Tiles: Improve handling of configuration issues

### DIFF
--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileGeneratorFeatures.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileGeneratorFeatures.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Range;
 import de.ii.xtraplatform.base.domain.LogContext;
+import de.ii.xtraplatform.cql.domain.BooleanValue2;
 import de.ii.xtraplatform.cql.domain.Cql;
 import de.ii.xtraplatform.cql.domain.Cql.Format;
 import de.ii.xtraplatform.cql.domain.Cql2Expression;
@@ -323,6 +324,13 @@ public class TileGeneratorFeatures implements TileGenerator, ChainedTileProvider
     String featureType = layer.getFeatureType().orElse(layer.getId());
     // TODO: from TilesProviders with orThrow
     FeatureSchema featureSchema = featureTypes.get(featureType);
+    // TODO: validate layer during provider startup
+    if (featureSchema == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Tile layer '%s' references feature type '%s', which does not exist.",
+              layer.getId(), featureType));
+    }
 
     ImmutableFeatureQuery.Builder queryBuilder =
         ImmutableFeatureQuery.builder()
@@ -339,11 +347,19 @@ public class TileGeneratorFeatures implements TileGenerator, ChainedTileProvider
           .forEach(filter -> queryBuilder.addFilters(cql.read(filter.getFilter(), Format.TEXT)));
     }
 
-    String spatialProperty = featureSchema.getPrimaryGeometry().orElseThrow().getFullPathAsString();
-    BoundingBox bbox = clip(tile.getBoundingBox(), bounds);
-    Cql2Expression spatialPredicate =
-        SIntersects.of(Property.of(spatialProperty), SpatialLiteral.of(Envelope.of(bbox)));
-    queryBuilder.addFilters(spatialPredicate);
+    featureSchema
+        .getPrimaryGeometry()
+        .map(SchemaBase::getFullPathAsString)
+        .ifPresentOrElse(
+            spatialProperty -> {
+              BoundingBox bbox = clip(tile.getBoundingBox(), bounds);
+              Cql2Expression spatialPredicate =
+                  SIntersects.of(
+                      Property.of(spatialProperty), SpatialLiteral.of(Envelope.of(bbox)));
+              queryBuilder.addFilters(spatialPredicate);
+            },
+            // TODO: validate feature schema during provider startup
+            () -> queryBuilder.addFilters(BooleanValue2.of(false)));
 
     if (userParameters.isPresent()) {
       userParameters.get().getLimit().ifPresent(queryBuilder::limit);


### PR DESCRIPTION
If a tile provider from features currently includes layers that reference a non-existing feature provider, an exception is thrown that does not provide a hint how to fix the configuration. This change throws an error, if there is no feature type associated with a layer. If the feature type has no primary geometry, the layer will now exclude all features instead of throwing an error.

The configuration should be validated during provider startup.