### PR TITLE
GPKG: Enforce LON_LAT order in auto mode

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
@@ -308,12 +308,9 @@ public class FeatureProviderSqlFactory
               .map(
                   property -> {
                     EpsgCrs crs = EpsgCrs.fromString(property.getAdditionalInfo().get("crs"));
-                    if (Objects.nonNull(data.getConnectionInfo())) {
-                      Dialect dialect = data.getConnectionInfo().getDialect();
-                      if (dialect == Dialect.GPKG) {
-                        // GPKG enforces LON_LAT order
-                        crs = EpsgCrs.of(crs.getCode(), Force.LON_LAT);
-                      }
+                    Force force = Force.valueOf(property.getAdditionalInfo().get("force"));
+                    if (force != crs.getForceAxisOrder()) {
+                      crs = EpsgCrs.of(crs.getCode(), force);
                     }
                     return crs;
                   })

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
@@ -13,6 +13,7 @@ import de.ii.xtraplatform.cql.domain.SpatialOperator;
 import de.ii.xtraplatform.cql.domain.TemporalOperator;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import de.ii.xtraplatform.crs.domain.EpsgCrs.Force;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -50,6 +51,10 @@ public interface SqlDialect {
   String escapeString(String value);
 
   String geometryInfoQuery(Map<String, String> dbInfo);
+
+  default EpsgCrs.Force forceAxisOrder(Map<String, String> dbInfo) {
+    return Force.NONE;
+  }
 
   List<String> getSystemTables();
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
@@ -11,6 +11,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
+import de.ii.xtraplatform.crs.domain.EpsgCrs.Force;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -139,6 +140,15 @@ public class SqlDialectGpkg implements SqlDialect {
     return String.format(
         "SELECT f_table_name AS \"%s\", f_geometry_column AS \"%s\", coord_dimension AS \"%s\", srid AS \"%s\", geometry_type AS \"%s\" FROM geometry_columns;",
         GeoInfo.TABLE, GeoInfo.COLUMN, GeoInfo.DIMENSION, GeoInfo.SRID, GeoInfo.TYPE);
+  }
+
+  @Override
+  public EpsgCrs.Force forceAxisOrder(Map<String, String> dbInfo) {
+    if (Objects.equals(dbInfo.get("spatial_metadata"), "GPKG")) {
+      return Force.LON_LAT;
+    }
+
+    return Force.NONE;
   }
 
   @Override

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -125,7 +125,8 @@ public class SchemaGeneratorSql implements SchemaGenerator, Closeable {
               try {
                 int srid = Integer.parseInt(geometryInfo.get(1));
                 if (srid > 0) {
-                  featureProperty.additionalInfo(ImmutableMap.of("crs", String.valueOf(srid)));
+                  featureProperty.additionalInfo(
+                      ImmutableMap.of("crs", String.valueOf(srid), "force", geometryInfo.get(2)));
                 }
               } catch (Throwable e) {
                 // ignore
@@ -181,6 +182,7 @@ public class SchemaGeneratorSql implements SchemaGenerator, Closeable {
     Map<String, List<String>> geometry = new HashMap<>();
     Map<String, String> dbInfo = sqlClient.getDbInfo();
     String query = dialect.geometryInfoQuery(dbInfo);
+    String force = dialect.forceAxisOrder(dbInfo).name();
 
     try {
       Statement stmt = connection.createStatement();
@@ -188,7 +190,7 @@ public class SchemaGeneratorSql implements SchemaGenerator, Closeable {
       while (rs.next()) {
         geometry.put(
             rs.getString(GeoInfo.TABLE),
-            ImmutableList.of(rs.getString(GeoInfo.TYPE), rs.getString(GeoInfo.SRID)));
+            ImmutableList.of(rs.getString(GeoInfo.TYPE), rs.getString(GeoInfo.SRID), force));
       }
     } catch (SQLException e) {
       LOGGER.debug("SQL QUERY EXCEPTION", e);


### PR DESCRIPTION
Closes https://github.com/interactive-instruments/ldproxy/issues/959

Tested with daraa.gpkg (EPSG:4326, requires LON_LAT enforcement) and Weinlagen.gpkg (EPSG:25832, already LON_LAT, or more correctly, Easting/Northing).