### PR TITLE
Memory leak when seeding a MBTiles cache

### DIFF
--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/SqlHelper.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/SqlHelper.java
@@ -14,13 +14,24 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 
 public class SqlHelper {
 
-  public static Connection getConnection(Path mbtilesFile) {
+  public static Properties READ_ONLY = getReadOnly();
+
+  public static Properties getReadOnly() {
+    Properties properties = new Properties();
+    properties.put("open_mode", "1");
+    return properties;
+  }
+
+  public static Connection getConnection(Path mbtilesFile, boolean readOnly) {
     try {
       Class.forName("org.sqlite.JDBC");
-      return DriverManager.getConnection("jdbc:sqlite:" + mbtilesFile);
+      return readOnly
+          ? DriverManager.getConnection("jdbc:sqlite:" + mbtilesFile, READ_ONLY)
+          : DriverManager.getConnection("jdbc:sqlite:" + mbtilesFile);
     } catch (SQLException | ClassNotFoundException e) {
       throw new IllegalStateException(
           "Connection to Mbtiles database could not be established.", e);

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
@@ -48,7 +48,6 @@ public class MbtilesTileset {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MbtilesTileset.class);
   private static final int EMPTY_TILE_ID = 1;
-  private Connection connection = null;
   private final Path tilesetPath;
   private final Semaphore mutex = new Semaphore(1);
   private final MbtilesMetadata metadata;
@@ -75,7 +74,7 @@ public class MbtilesTileset {
     this.metadata = metadata;
 
     // create and init MBTiles DB
-    releaseConnection(getConnection(true));
+    releaseConnection(getConnection(true, false));
   }
 
   private void initMbtilesDb(MbtilesMetadata metadata, Connection connection) {
@@ -164,8 +163,9 @@ public class MbtilesTileset {
     }
   }
 
-  private Connection getConnection(boolean aquireMutexOnCreate) throws IOException {
-    // we use a single connection per database to avoid multi-threading conflicts
+  private Connection getConnection(boolean aquireMutexOnCreate, boolean readOnly)
+      throws IOException {
+    Connection connection = null;
 
     // check, if the file exists
     if (!Files.exists(tilesetPath)) {
@@ -184,10 +184,10 @@ public class MbtilesTileset {
           // recreate an empty MBTiles container
           LOGGER.trace("Creating MBTiles file '{}'.", tilesetPath);
           Files.createDirectories(tilesetPath.getParent());
-          connection = SqlHelper.getConnection(tilesetPath);
+          connection = SqlHelper.getConnection(tilesetPath, false);
           initMbtilesDb(metadata, connection);
-        } else if (Objects.isNull(connection)) {
-          connection = SqlHelper.getConnection(tilesetPath);
+        } else {
+          connection = SqlHelper.getConnection(tilesetPath, readOnly);
         }
       } catch (InterruptedException e) {
         LOGGER.debug("getConnection: Thread has been interrupted.");
@@ -197,8 +197,8 @@ public class MbtilesTileset {
           mutex.release();
         }
       }
-    } else if (Objects.isNull(connection)) {
-      connection = SqlHelper.getConnection(tilesetPath);
+    } else {
+      connection = SqlHelper.getConnection(tilesetPath, readOnly);
     }
 
     return connection;
@@ -206,18 +206,20 @@ public class MbtilesTileset {
 
   private void releaseConnection(@Nullable Connection connection) {
     try {
-      connection.close();
+      if (connection != null) {
+        connection.close();
+      }
     } catch (SQLException e) {
       throw new IllegalStateException(
           String.format(
-              "Failed to close SQLite connection to MBTiles store.. Reason: %s", e.getMessage()),
+              "Failed to close SQLite connection to MBTiles store. Reason: %s", e.getMessage()),
           e);
     }
   }
 
   public MbtilesMetadata getMetadata() throws SQLException, IOException {
     ImmutableMbtilesMetadata.Builder builder = ImmutableMbtilesMetadata.builder();
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, true);
     ResultSet rs = SqlHelper.executeQuery(connection, "SELECT name, value FROM metadata");
     while (rs.next()) {
       final String name = rs.getString("name");
@@ -340,7 +342,7 @@ public class MbtilesTileset {
     int row = tile.getTileMatrixSet().getTmsRow(level, tile.getRow());
     int col = tile.getCol();
     boolean gzip = Objects.equals(tile.getMediaType(), FeatureEncoderMVT.FORMAT);
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, true);
     String sql =
         String.format(
             "SELECT tile_data FROM tiles WHERE zoom_level=%d AND tile_row=%d AND tile_column=%d",
@@ -359,7 +361,7 @@ public class MbtilesTileset {
 
   public Optional<Boolean> tileIsEmpty(TileCoordinates tile) throws SQLException, IOException {
     Optional<Boolean> result = Optional.empty();
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, true);
     int level = tile.getLevel();
     int row = tile.getTileMatrixSet().getTmsRow(level, tile.getRow());
     int col = tile.getCol();
@@ -381,7 +383,7 @@ public class MbtilesTileset {
   }
 
   public void walk(Walker walker) throws SQLException, IOException {
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, false);
     String sql = "SELECT zoom_level, tile_row, tile_column FROM tile_map";
     ResultSet rs = SqlHelper.executeQuery(connection, sql);
 
@@ -401,7 +403,7 @@ public class MbtilesTileset {
   }
 
   public boolean tileExists(int level, int row, int col) throws SQLException, IOException {
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, true);
     String sql =
         String.format(
             "SELECT tile_data FROM tiles WHERE zoom_level=%d AND tile_row=%d AND tile_column=%d",
@@ -412,7 +414,7 @@ public class MbtilesTileset {
   }
 
   public boolean hasAnyTiles() throws SQLException, IOException {
-    Connection connection = getConnection(true);
+    Connection connection = getConnection(true, true);
     String sql = "SELECT COUNT(*) FROM tile_blobs";
     ResultSet resultSet = SqlHelper.executeQuery(connection, sql);
     long count = resultSet.getLong(1);
@@ -441,7 +443,7 @@ public class MbtilesTileset {
       if (!aquired)
         throw new IllegalStateException(
             String.format("Could not aquire mutex to create MBTiles file: %s", tilesetPath));
-      connection = getConnection(false);
+      connection = getConnection(false, false);
       // do we have an old blob?
       boolean exists = false;
       Integer old_tile_id = null;
@@ -541,7 +543,7 @@ public class MbtilesTileset {
       if (!aquired)
         throw new IllegalStateException(
             String.format("Could not aquire mutex to create MBTiles file: %s", tilesetPath));
-      connection = getConnection(false);
+      connection = getConnection(false, false);
       String sql =
           String.format(
               "SELECT tile_id FROM tile_map WHERE zoom_level=%d AND tile_row=%d AND tile_column=%d",
@@ -583,7 +585,7 @@ public class MbtilesTileset {
       if (!aquired)
         throw new IllegalStateException(
             String.format("Could not aquire mutex to create MBTiles file: %s", tilesetPath));
-      connection = getConnection(false);
+      connection = getConnection(false, false);
       String sqlFrom =
           String.format(
               "FROM tile_map WHERE zoom_level=%d AND tile_row>=%d AND tile_column>=%d AND tile_row<=%d AND tile_column<=%d",

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
@@ -205,7 +205,14 @@ public class MbtilesTileset {
   }
 
   private void releaseConnection(@Nullable Connection connection) {
-    // nothing to do
+    try {
+      connection.close();
+    } catch (SQLException e) {
+      throw new IllegalStateException(
+          String.format(
+              "Failed to close SQLite connection to MBTiles store.. Reason: %s", e.getMessage()),
+          e);
+    }
   }
 
   public MbtilesMetadata getMetadata() throws SQLException, IOException {


### PR DESCRIPTION
Closes https://github.com/interactive-instruments/ldproxy/issues/968. 
Closes https://github.com/interactive-instruments/ldproxy-project-management/issues/166.

So far, a single SQLite connection was used for each MBTiles cache, which is often recommended. However, it turns out, that the steady memory increase in the container goes away, if the connection is opened/closed for every function (e.g., writing a tile or fetching a tile).

For functions that only need read-access, the connection is opened as read-only.

The change has no effect on the times needed to seed immutable MBTILES tile caches of the demo configuration (vineyards, daraa, and strassen). As an aside, I also compared tiles with seeding PLAIN caches: PLAIN was at 15% faster than MBTILES for vineyards/strassen and 30% faster for daraa.

I also tested seeding DYNAMIC tile caches with multiple threads and accessing/creating tiles by accessing tiles via the API during the seeding. I did not encounter any exceptions due to conflicts while tiles are being written from the seeding task as well as from the API requests.