### PR TITLE
include ID properties in schemas in all scopes

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/WithScope.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/WithScope.java
@@ -31,7 +31,9 @@ public class WithScope implements SchemaVisitorTopDown<FeatureSchema, FeatureSch
   public FeatureSchema visit(
       FeatureSchema schema, List<FeatureSchema> parents, List<FeatureSchema> visitedProperties) {
 
-    if (schema.getScope().isPresent() && !Objects.equals(schema.getScope().get(), scope)) {
+    if (schema.getScope().isPresent()
+        && !Objects.equals(schema.getScope().get(), scope)
+        && !schema.isId()) {
       return null;
     }
 


### PR DESCRIPTION
If ID properties are not included in the schema, CRUD operations will fail (even if the ID is not part of the payload). This includes DELETE, too.