### PR TITLE
Tiles: Address comments/issues from the OGC June 2023 Code Sprint

### DIFF
--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/FeatureEncoderMVT.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/FeatureEncoderMVT.java
@@ -131,7 +131,10 @@ public class FeatureEncoderMVT extends FeatureEncoderSfFlat {
       }
 
       // in "full" tiles all features cover then whole tile
-      full = full && tileGeometry.equals(clipGeometry);
+      try {
+        full = full && tileGeometry.equals(clipGeometry);
+      } catch (Exception ignore) {
+      }
 
       // if polygons have to be merged, store them for now and process at the end
       if (Objects.nonNull(groupBy) && tileGeometry.getGeometryType().contains("Polygon")) {
@@ -180,13 +183,14 @@ public class FeatureEncoderMVT extends FeatureEncoderSfFlat {
 
     } catch (Exception e) {
       LOGGER.error(
-          "Error while processing feature {} in tile {}/{}/{}/{} in tileset {}. The feature is skipped.",
+          "Error while processing feature {} in tile {}/{}/{}/{} in tileset {}. The feature is skipped. Reason: {}",
           feature.getIdValue(),
           tile.getTileMatrixSet().getId(),
           tile.getLevel(),
           tile.getRow(),
           tile.getCol(),
-          tileset);
+          tileset,
+          e.getMessage());
       if (LOGGER.isDebugEnabled(LogContext.MARKER.STACKTRACE)) {
         LOGGER.debug(LogContext.MARKER.STACKTRACE, "Stacktrace:", e);
       }

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileGeometryUtil.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileGeometryUtil.java
@@ -75,9 +75,14 @@ public class TileGeometryUtil {
     geom = GeometryPrecisionReducer.reducePointwise(geom, precisionModel);
     if (Objects.isNull(geom) || geom.isEmpty()) return null;
 
-    // 6 if the resulting geometry is invalid, try to make it valid
-    if (!geom.isValid()) {
-      geom = new GeometryFixer(geom).getResult();
+    // 6 if the resulting geometry is invalid, try to make it valid and ensure it is still aligned
+    //   with the tile grid; give up, if it is still invalid after two attempts
+    int count = 0;
+    while (!geom.isValid() && count++ < 2) {
+      geom = GeometryFixer.fix(geom);
+      if (Objects.isNull(geom) || geom.isEmpty()) return null;
+
+      geom = GeometryPrecisionReducer.reducePointwise(geom, precisionModel);
       if (Objects.isNull(geom) || geom.isEmpty()) return null;
     }
 


### PR DESCRIPTION
- Improve tile geometry validity
  - If a tile geometry is invalid, continue to try to fix it, but reduce the result again to the tile grid. Stop after two attempts.
- Small improvements 
  - If determining a "full" tile fails, simply ignore the exception and assume false.
  - Log the error message for invalid tile geometries.
