### PR TITLE
add hasFeatures to FeatureStream.Result

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureStream.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureStream.java
@@ -101,6 +101,8 @@ public interface FeatureStream {
 
       public abstract U isEmpty(boolean isEmpty);
 
+      public abstract U hasFeatures(boolean hasFeatures);
+
       public abstract U error(Throwable error);
 
       public abstract T build();
@@ -112,6 +114,8 @@ public interface FeatureStream {
     }
 
     boolean isEmpty();
+
+    boolean hasFeatures();
 
     Optional<Throwable> getError();
   }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureStreamImpl.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureStreamImpl.java
@@ -84,13 +84,15 @@ public class FeatureStreamImpl implements FeatureStream {
             source = source.via(new FeatureTokenTransformerWeakETag(resultBuilder));
           }
 
+          source = source.via(new FeatureTokenTransformerHasFeatures(resultBuilder));
+
           Reactive.BasicStream<?, Void> basicStream =
               sink instanceof Reactive.SinkTransformed
                   ? source.to((Reactive.SinkTransformed<Object, ?>) sink)
                   : source.to(sink);
 
           return basicStream
-              .withResult(resultBuilder.isEmpty(true))
+              .withResult(resultBuilder.isEmpty(true).hasFeatures(false))
               .handleError(ImmutableResult.Builder::error)
               .handleItem(
                   (builder, x) -> {
@@ -138,13 +140,15 @@ public class FeatureStreamImpl implements FeatureStream {
             source = source.via(new FeatureTokenTransformerWeakETag(resultBuilder));
           }
 
+          source = source.via(new FeatureTokenTransformerHasFeatures(resultBuilder));
+
           Reactive.BasicStream<?, X> basicStream =
               sink instanceof Reactive.SinkReducedTransformed
                   ? source.to((Reactive.SinkReducedTransformed<Object, ?, X>) sink)
                   : source.to(sink);
 
           return basicStream
-              .withResult(resultBuilder.isEmpty(true))
+              .withResult(resultBuilder.isEmpty(true).hasFeatures(false))
               .handleError(ImmutableResultReduced.Builder::error)
               .handleItem(
                   (builder, x) -> {

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTokenTransformerHasFeatures.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTokenTransformerHasFeatures.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain;
+
+import de.ii.xtraplatform.features.domain.ImmutableResult.Builder;
+import java.util.function.Consumer;
+
+public class FeatureTokenTransformerHasFeatures extends FeatureTokenTransformer {
+
+  private final Consumer<Boolean> setter;
+  private boolean done;
+
+  public FeatureTokenTransformerHasFeatures(Builder resultBuilder) {
+    this.setter = resultBuilder::hasFeatures;
+    this.done = false;
+  }
+
+  public <X> FeatureTokenTransformerHasFeatures(ImmutableResultReduced.Builder<X> resultBuilder) {
+    this.setter = resultBuilder::hasFeatures;
+    this.done = false;
+  }
+
+  @Override
+  public void onFeatureStart(ModifiableContext<FeatureSchema, SchemaMapping> context) {
+    if (!done) {
+      this.done = true;
+      setter.accept(true);
+    }
+
+    super.onFeatureStart(context);
+  }
+}


### PR DESCRIPTION
`Result.isEmpty` is only true if there were no bytes written. But there might be bytes written even if the query did not result in any features. To detect this case, this adds `Result.hasFeatures`.