### PR TITLE
Incorrect conversion of CQL2 to SQL 

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlImpl.java
@@ -152,6 +152,13 @@ public class CqlImpl implements Cql {
     return (Cql2Expression) cqlFilter.accept(visitor, true);
   }
 
+  @Override
+  public Cql2Expression mapNots(Cql2Expression cqlFilter) {
+    CqlVisitorMapNots visitor = new CqlVisitorMapNots();
+
+    return (Cql2Expression) cqlFilter.accept(visitor, true);
+  }
+
   static class IntervalConverter extends StdConverter<Interval, List<String>> {
 
     @Override

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorMapNots.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/app/CqlVisitorMapNots.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.app;
+
+import de.ii.xtraplatform.cql.domain.And;
+import de.ii.xtraplatform.cql.domain.Cql2Expression;
+import de.ii.xtraplatform.cql.domain.CqlNode;
+import de.ii.xtraplatform.cql.domain.Eq;
+import de.ii.xtraplatform.cql.domain.Gt;
+import de.ii.xtraplatform.cql.domain.Gte;
+import de.ii.xtraplatform.cql.domain.Lt;
+import de.ii.xtraplatform.cql.domain.Lte;
+import de.ii.xtraplatform.cql.domain.Neq;
+import de.ii.xtraplatform.cql.domain.Not;
+import de.ii.xtraplatform.cql.domain.Or;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CqlVisitorMapNots extends CqlVisitorCopy {
+
+  @Override
+  public CqlNode visit(Not not, List<CqlNode> children) {
+
+    return map(not.getArgs().get(0));
+  }
+
+  private Cql2Expression map(Cql2Expression arg) {
+    if (arg instanceof Or) {
+      return And.of(
+          ((Or) arg).getArgs().stream().map(this::map).collect(Collectors.toUnmodifiableList()));
+    } else if (arg instanceof And) {
+      return Or.of(
+          ((And) arg).getArgs().stream().map(this::map).collect(Collectors.toUnmodifiableList()));
+    } else if (arg instanceof Not) {
+      return ((Not) arg).getArgs().get(0);
+    } else if (arg instanceof Eq) {
+      return Neq.of(((Eq) arg).getArgs());
+    } else if (arg instanceof Neq) {
+      return Eq.of(((Neq) arg).getArgs());
+    } else if (arg instanceof Lt) {
+      return Gte.of(((Lt) arg).getArgs());
+    } else if (arg instanceof Gt) {
+      return Lte.of(((Gt) arg).getArgs());
+    } else if (arg instanceof Lte) {
+      return Gt.of(((Lte) arg).getArgs());
+    } else if (arg instanceof Gte) {
+      return Lt.of(((Gte) arg).getArgs());
+    }
+    return Not.of(arg);
+  }
+}

--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/Cql.java
@@ -44,4 +44,6 @@ public interface Cql {
       Cql2Expression cqlFilter, Set<TemporalOperator> supportedOperators);
 
   Cql2Expression mapEnvelopes(Cql2Expression cqlFilter, CrsInfo crsInfo);
+
+  Cql2Expression mapNots(Cql2Expression cqlFilter);
 }

--- a/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlNotMapperSpec.groovy
+++ b/xtraplatform-cql/src/test/groovy/de/ii/xtraplatform/cql/app/CqlNotMapperSpec.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.cql.app
+
+import de.ii.xtraplatform.cql.domain.And
+import de.ii.xtraplatform.cql.domain.Cql
+import de.ii.xtraplatform.cql.domain.Cql2Expression
+import de.ii.xtraplatform.cql.domain.Eq
+import de.ii.xtraplatform.cql.domain.Gt
+import de.ii.xtraplatform.cql.domain.Lte
+import de.ii.xtraplatform.cql.domain.Neq
+import de.ii.xtraplatform.cql.domain.Not
+import de.ii.xtraplatform.cql.domain.Or
+import de.ii.xtraplatform.cql.domain.Property
+import de.ii.xtraplatform.cql.domain.ScalarLiteral
+import spock.lang.Shared
+import spock.lang.Specification
+
+class CqlNotMapperSpec extends Specification {
+
+    @Shared
+    Cql cql
+
+    def setupSpec() {
+        cql = new CqlImpl()
+    }
+
+    def 'Test the visitor that maps NOT predicates'() {
+        given:
+        CqlVisitorMapNots visitor = new CqlVisitorMapNots()
+
+        when:
+        def actual = CqlFilterExamples.EXAMPLE_NOT.accept(visitor, true)
+
+        Cql2Expression eq1 = Eq.of(Property.of("test"), ScalarLiteral.of(1))
+        Cql2Expression neq1 = Neq.of(Property.of("test1"), ScalarLiteral.of(1))
+        Cql2Expression eq2 = Eq.of(Property.of("test2"), ScalarLiteral.of("foo"))
+        Cql2Expression lte1 = Lte.of(Property.of("test3"), ScalarLiteral.of("bar"))
+        Cql2Expression neq2 = Neq.of(Property.of("test"), ScalarLiteral.of(1))
+        Cql2Expression expected = Or.of(eq1, And.of(neq1, eq2, lte1), Or.of(neq1, eq2, lte1), neq2)
+
+        then:
+        actual == expected
+    }
+
+}

--- a/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
+++ b/xtraplatform-cql/src/testFixtures/java/de/ii/xtraplatform/cql/app/CqlFilterExamples.java
@@ -1008,4 +1008,18 @@ public class CqlFilterExamples {
       AContainedBy.of(
           Property.of("location"),
           ArrayLiteral.of(ImmutableList.of(ScalarLiteral.of("id"), ScalarLiteral.of("location"))));
+
+  public static final Cql2Expression EXAMPLE_NOT =
+      Not.of(
+          And.of(
+              Not.of(Eq.of(Property.of("test"), ScalarLiteral.of(1))),
+              Or.of(
+                  Eq.of(Property.of("test1"), ScalarLiteral.of(1)),
+                  Neq.of(Property.of("test2"), ScalarLiteral.of("foo")),
+                  Gt.of(Property.of("test3"), ScalarLiteral.of("bar"))),
+              And.of(
+                  Eq.of(Property.of("test1"), ScalarLiteral.of(1)),
+                  Neq.of(Property.of("test2"), ScalarLiteral.of("foo")),
+                  Gt.of(Property.of("test3"), ScalarLiteral.of("bar"))),
+              Eq.of(Property.of("test"), ScalarLiteral.of(1))));
 }


### PR DESCRIPTION
Closes https://github.com/interactive-instruments/ldproxy/issues/1007

Changes:

- Pre-process CQL2 expressions to apply De Morgan's law to resolve NOT expressions on AND or OR expressions.
- Handle NOT in SQL subqueries properly to honor the three-valued logic.
- Unit tests have been updated.

Open issues:

- [ ] Build fails, because tests fail. However, the tests also fail in master, so it is not yet clear to me what has changed.

The updated code has been tested against https://docs.ogc.org/DRAFTS/21-065.html#_conformance_test_9. Test configuration is `cql2test`. Some of the current values are incorrect (because ldproxy so far converted the CQL2 incorrectly to SQL and I used the ldproxy results as the reference value...). The affected values are:

121 instead of 242 for:
(NOT (pop_other>1038288) AND pop_other<1038288) OR (pop_other IS NULL and start<TIMESTAMP('2022-04-16T10:13:19Z')) or not (pop_other<1038288 OR start<TIMESTAMP('2022-04-16T10:13:19Z'))

2 instead of 138 for:
(NOT (name<>'København') AND start<=TIMESTAMP('2022-04-16T10:13:19Z')) OR (boolean=true and name<'København') or not (start<=TIMESTAMP('2022-04-16T10:13:19Z') OR name<'København')

2 instead of 123 for:
(NOT (name<>'København') AND pop_other<1038288) OR (name='København' and start<TIMESTAMP('2022-04-16T10:13:19Z')) or not (pop_other<1038288 OR start<TIMESTAMP('2022-04-16T10:13:19Z'))

122 instead of 241 for:
(NOT (name IS NOT NULL) AND start>=TIMESTAMP('2022-04-16T10:13:19Z')) OR (start IS NULL and pop_other>1038288) or not (start>=TIMESTAMP('2022-04-16T10:13:19Z') OR pop_other>1038288)

137 instead of 241 for:
(NOT (start IS NOT NULL) AND name>='København') OR (boolean=true and start>=TIMESTAMP('2022-04-16T10:13:19Z')) or not (name>='København' OR start>=TIMESTAMP('2022-04-16T10:13:19Z'))

3 instead of 139 for:
(NOT (name>'København') AND start>=TIMESTAMP('2022-04-16T10:13:19Z')) OR (pop_other=1038288 and name<'København') or not (start>=TIMESTAMP('2022-04-16T10:13:19Z') OR name<'København')

138 instead of 242 for:
(NOT (name<='København') AND start<TIMESTAMP('2022-04-16T10:13:19Z')) OR (boolean IS NULL and name>'København') or not (start<TIMESTAMP('2022-04-16T10:13:19Z') OR name>'København')

2 instead of 242 for:
(NOT (pop_other<1038288) AND start>TIMESTAMP('2022-04-16T10:13:19Z')) OR (name<='København' and pop_other=1038288) or not (start>TIMESTAMP('2022-04-16T10:13:19Z') OR pop_other=1038288)

3 instead of 243 for:
(NOT (start<=TIMESTAMP('2022-04-16T10:13:19Z')) AND pop_other<>1038288) OR (start IS NOT NULL and start=TIMESTAMP('2022-04-16T10:13:19Z')) or not (pop_other<>1038288 OR start=TIMESTAMP('2022-04-16T10:13:19Z'))

3 instead of 243 for:
(NOT (pop_other<1038288) AND boolean=true) OR (name IS NOT NULL and start<=TIMESTAMP('2022-04-16T10:13:19Z')) or not (boolean=true OR start<=TIMESTAMP('2022-04-16T10:13:19Z'))

2 instead of 242 for:
(NOT (name<='København') AND pop_other IS NULL) OR (name='København' and start>TIMESTAMP('2022-04-16T10:13:19Z')) or not (pop_other IS NULL OR start>TIMESTAMP('2022-04-16T10:13:19Z'))

1 instead of 122 for:
(NOT (start>=TIMESTAMP('2022-04-16T10:13:19Z')) AND start>TIMESTAMP('2022-04-16T10:13:19Z')) OR (pop_other IS NULL and pop_other<=1038288) or not (start>TIMESTAMP('2022-04-16T10:13:19Z') OR pop_other<=1038288)

199 instead of 241 for:
(NOT (start>=TIMESTAMP('2022-04-16T10:13:19Z')) AND pop_other<1038288) OR (name>'København' and pop_other<=1038288) or not (pop_other<1038288 OR pop_other<=1038288)

1 instead of 120 for:
(NOT (start<TIMESTAMP('2022-04-16T10:13:19Z')) AND pop_other<1038288) OR (name IS NULL and pop_other>=1038288) or not (pop_other<1038288 OR pop_other>=1038288)

2 instead of 138 for:
(NOT (boolean IS NULL) AND start<TIMESTAMP('2022-04-16T10:13:19Z')) OR (start>TIMESTAMP('2022-04-16T10:13:19Z') and name<'København') or not (start<TIMESTAMP('2022-04-16T10:13:19Z') OR name<'København')