### PR TITLE
set hasFeatures in mutation results

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSql.java
@@ -748,7 +748,7 @@ public class FeatureProviderSql
     RunnableStream<MutationResult> deletionStream =
         deletionSource
             .to(Sink.ignore())
-            .withResult(ImmutableMutationResult.builder().type(Type.DELETE))
+            .withResult(ImmutableMutationResult.builder().type(Type.DELETE).hasFeatures(false))
             .handleError(ImmutableMutationResult.Builder::error)
             .handleItem(ImmutableMutationResult.Builder::addIds)
             .handleEnd(Builder::build)
@@ -797,7 +797,8 @@ public class FeatureProviderSql
 
     ImmutableMutationResult.Builder builder =
         ImmutableMutationResult.builder()
-            .type(featureId.isPresent() ? partial ? Type.UPDATE : Type.REPLACE : Type.CREATE);
+            .type(featureId.isPresent() ? partial ? Type.UPDATE : Type.REPLACE : Type.CREATE)
+            .hasFeatures(false);
     FeatureTokenStatsCollector statsCollector = new FeatureTokenStatsCollector(builder, crs);
 
     Source<FeatureSql> featureSqlSource =


### PR DESCRIPTION
Closes https://github.com/interactive-instruments/ldproxy/issues/1027

Tested with the daraa API:

```sh
curl -i -X POST "http://localhost:7080/rest/services/daraa/collections/CulturePnt/items" -H  "Content-Type: application/geo+json" -d "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[36.0864929,32.6010818]},\"properties\":{\"F_CODE\":\"AL030\",\"ZI001_SDV\":\"2015-12-27T18:39:59Z\",\"UFI\":\"7ab54c93-b054-406f-9cf1-6921fd633277\",\"ZI005_FNA\":\"Test\",\"FCSUBTYPE\":100092,\"ZI037_REL\":11}}"

curl -i -X PUT "http://localhost:7080/rest/services/daraa/collections/CulturePnt/items/6" -H  "Content-Type: application/geo+json" -d "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[36.1864929,32.7010818]},\"properties\":{\"F_CODE\":\"AL030\",\"ZI001_SDV\":\"2017-12-27T18:39:59Z\",\"UFI\":\"7ab54c93-b054-406f-9cf1-6921fd633277\",\"ZI005_FNA\":\"Test2\",\"FCSUBTYPE\":100092,\"ZI037_REL\":11}}"

curl -i -X PATCH "http://localhost:7080/rest/services/daraa/collections/CulturePnt/items/6" -H  "Content-Type: application/geo+json" -d "{\"geometry\":{\"type\":\"Point\",\"coordinates\":[36.2864929,32.6010818]}}"

curl -i -X PATCH "http://localhost:7080/rest/services/daraa/collections/CulturePnt/items/6" -H  "Content-Type: application/geo+json" -d "{\"properties\":{\"ZI001_SDV\":\"2018-12-27T18:39:59Z\",\"ZI005_FNA\":\"Test3\"}}"

curl -i -X DELETE "http://localhost:7080/rest/services/daraa/collections/CulturePnt/items/6"
```