### PR TITLE
fix handling CRUD requests with FEATURE_REF properties

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/ObjectSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/ObjectSql.java
@@ -207,7 +207,10 @@ public interface ObjectSql {
                       .getSchema()
                       .map(
                           schemaSql ->
-                              schemaSql.getType() == SchemaBase.Type.STRING
+                              (schemaSql.getType() == SchemaBase.Type.FEATURE_REF
+                                      && schemaSql.getValueType().orElse(SchemaBase.Type.STRING)
+                                          == SchemaBase.Type.STRING)
+                                  || schemaSql.getType() == SchemaBase.Type.STRING
                                   || schemaSql.getType() == SchemaBase.Type.DATETIME)
                       .orElse(false);
 


### PR DESCRIPTION
When creating the INSERT statements for a column with type FEATURE_REF, the value was not quoted. As a result, inserting the value 0-20000-0-60191 resulted in the value -80191 in the database. This change quotes also FEATURE_REF values of value type STRING.

Note: No issue is required since FEATURE_REF will only be introduced in v3.5.0.