### PR TITLE
upgrade  jsonschemafriend

### DIFF
--- a/xtraplatform-schemas-ext/build.gradle
+++ b/xtraplatform-schemas-ext/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     provided project(':xtraplatform-features')
     provided project(':xtraplatform-geometries')
 
-    embeddedFlat 'net.jimblackler.jsonschemafriend:core:0.11.4'
+    embeddedFlat 'net.jimblackler.jsonschemafriend:core:0.12.2'
     embeddedFlat 'com.damnhandy:handy-uri-templates:2.1.8'
     embedded 'org.jruby.joni:joni:2.1.41'
 

--- a/xtraplatform-schemas-ext/build.gradle
+++ b/xtraplatform-schemas-ext/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     embeddedFlat 'net.jimblackler.jsonschemafriend:core:0.12.2'
     embeddedFlat 'com.damnhandy:handy-uri-templates:2.1.8'
     embedded 'org.jruby.joni:joni:2.1.41'
+    embedded 'org.jsoup:jsoup:1.14.2'
 
     testImplementation(testFixtures(project(":xtraplatform-features")))
     testImplementation project(':xtraplatform-crs')


### PR DESCRIPTION
closes https://github.com/interactive-instruments/ldproxy/issues/1068

This seems to fix the issue, but it would be good to understand why the old version stopped to work.