### PR TITLE
queryable dynamic feature references

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeatureRefResolver.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeatureRefResolver.java
@@ -96,7 +96,13 @@ public class FeatureRefResolver implements SchemaVisitorTopDown<FeatureSchema, F
               visitedProperties.stream()
                   .flatMap(
                       property -> {
-                        if (property.isFeatureRef() && isStatic(property.getRefType())) {
+                        if (property.isFeatureRef()
+                            && (isStatic(property.getRefType())
+                                || property.getProperties().stream()
+                                    .anyMatch(
+                                        p ->
+                                            p.getName().equals("type")
+                                                && p.getSourcePath().isPresent()))) {
                           Optional<FeatureSchema> idProperty =
                               property.getProperties().stream()
                                   .filter(Objects::nonNull)


### PR DESCRIPTION
Currently, only static feature references (fixed `refType`) are handled in `FeatureRefResolver`. There are, however, cases where dynamic feature references can be queryable, too. This is the case, if the type is determined by a `type` property that is not constant, but takes the `refType` value from a column. No concat/coalesce is used in this case.