### PR TITLE
fix for types without a queryable

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlyQueryables.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlyQueryables.java
@@ -78,7 +78,7 @@ public class OnlyQueryables implements SchemaVisitorTopDown<FeatureSchema, Featu
           return null;
         }
       } else if (!schema.isObject()
-          || (parents.isEmpty() && visitedProperties.stream().noneMatch(Objects::nonNull))) {
+          || (!parents.isEmpty() && visitedProperties.stream().noneMatch(Objects::nonNull))) {
         return null;
       }
 


### PR DESCRIPTION
The queryables schema of a feature without a queryable is a schema without a property, not null. This was intended to be fixed by a commit in #233, but the fix was incorrect.