### PR TITLE
revert moving LocalSchemaFragmentResolver

### DIFF
--- a/xtraplatform-schemas-ext/src/main/java/de/ii/xtraplatform/schemas/ext/app/LocalSchemaFragmentResolver.java
+++ b/xtraplatform-schemas-ext/src/main/java/de/ii/xtraplatform/schemas/ext/app/LocalSchemaFragmentResolver.java
@@ -5,7 +5,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package de.ii.xtraplatform.features.app;
+package de.ii.xtraplatform.schemas.ext.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
 import de.ii.xtraplatform.features.domain.FeatureProviderDataV2;


### PR DESCRIPTION
For some reason, `LocalSchemaFragmentResolver` is no longer found after the move from `schemas.ext` to `features` in #248. While the class belongs to features, I revert the move temporarily until the proper fix has been implemented.