### PR TITLE
support removing change listeners

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/app/FeatureChangeHandlerImpl.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/app/FeatureChangeHandlerImpl.java
@@ -36,6 +36,16 @@ public class FeatureChangeHandlerImpl implements FeatureChangeHandler {
   }
 
   @Override
+  public void removeListener(DatasetChangeListener listener) {
+    datasetListeners.remove(listener);
+  }
+
+  @Override
+  public void removeListener(FeatureChangeListener listener) {
+    featureListeners.remove(listener);
+  }
+
+  @Override
   public void handle(DatasetChange change) {
     datasetListeners.forEach(listener -> listener.onDatasetChange(change));
   }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureChangeHandler.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureChangeHandler.java
@@ -13,6 +13,10 @@ public interface FeatureChangeHandler {
 
   void addListener(FeatureChangeListener listener);
 
+  void removeListener(DatasetChangeListener listener);
+
+  void removeListener(FeatureChangeListener listener);
+
   void handle(DatasetChange change);
 
   void handle(FeatureChange change);

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/ProviderData.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/ProviderData.java
@@ -8,6 +8,7 @@
 package de.ii.xtraplatform.features.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import de.ii.xtraplatform.docs.DocIgnore;
 import de.ii.xtraplatform.entities.domain.EntityData;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -28,5 +29,23 @@ public interface ProviderData extends EntityData {
   default Optional<String> getEntitySubType() {
     return Optional.of(
         String.format("%s/%s", getProviderType(), getProviderSubType()).toLowerCase());
+  }
+
+  // We need to add the @Value.Auxiliary annotation here again, otherwise createdAt and lastModified
+  // are still included in the hash. This may be a bug in the immutables?
+  @DocIgnore
+  @Value.Default
+  @Value.Auxiliary
+  @Override
+  default long getCreatedAt() {
+    return EntityData.super.getCreatedAt();
+  }
+
+  @DocIgnore
+  @Value.Default
+  @Value.Auxiliary
+  @Override
+  default long getLastModified() {
+    return EntityData.super.getLastModified();
   }
 }


### PR DESCRIPTION
When an API entity is reloaded or removed, the existing change listeners are still registered in the handler. They need to be removed on reload or shutdown.