### PR TITLE
compute key data hashes once

### DIFF
--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureProviderWfsData.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureProviderWfsData.java
@@ -71,7 +71,7 @@ import org.immutables.value.Value;
             @DocStep(type = Step.TAG, params = "{@examplesAll}")
           })
     })
-@Value.Immutable
+@Value.Immutable(prehash = true)
 @Value.Style(
     builder = "new",
     deepImmutablesDetection = true,

--- a/xtraplatform-features-graphql/src/main/java/de/ii/xtraplatform/features/graphql/domain/FeatureProviderGraphQlData.java
+++ b/xtraplatform-features-graphql/src/main/java/de/ii/xtraplatform/features/graphql/domain/FeatureProviderGraphQlData.java
@@ -137,7 +137,7 @@ import org.immutables.value.Value;
           },
           columnSet = ColumnSet.JSON_PROPERTIES),
     })
-@Value.Immutable
+@Value.Immutable(prehash = true)
 @BuildableMapEncodingEnabled
 @JsonDeserialize(builder = ImmutableFeatureProviderGraphQlData.Builder.class)
 public interface FeatureProviderGraphQlData

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
@@ -160,7 +160,7 @@ import org.immutables.value.Value;
           },
           columnSet = ColumnSet.JSON_PROPERTIES),
     })
-@Value.Immutable
+@Value.Immutable(prehash = true)
 @Value.Style(
     builder = "new",
     deepImmutablesDetection = true,

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SchemaSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SchemaSql.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.immutables.value.Value;
 
-@Value.Immutable
+@Value.Immutable(lazyhash = true)
 @Value.Style(deepImmutablesDetection = true, builder = "new", attributeBuilderDetection = true)
 public interface SchemaSql extends SchemaBase<SchemaSql> {
 

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderCommonData.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderCommonData.java
@@ -16,7 +16,7 @@ import de.ii.xtraplatform.entities.domain.maptobuilder.encoding.BuildableMapEnco
 import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
-@Value.Immutable
+@Value.Immutable(prehash = true)
 @Value.Style(
     builder = "new",
     deepImmutablesDetection = true,

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
@@ -37,7 +37,7 @@ import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Value.Immutable
+@Value.Immutable(lazyhash = true)
 @Value.Style(
     builder = "new",
     deepImmutablesDetection = true,


### PR DESCRIPTION
Compute key data hashes that are often called several times per object only once. For entities, where `hashCode()` is called at several times, pre-compute the hash. For schema objects, compute the hash lazily.