### PR TITLE
include feature ref properties in projection

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/WithoutProperties.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/WithoutProperties.java
@@ -33,7 +33,7 @@ public class WithoutProperties implements SchemaVisitorTopDown<FeatureSchema, Fe
     if (!schema.isPrimaryGeometry()
         && !fields.isEmpty()
         && !parents.isEmpty()
-        && !fields.contains(schema.getFullPathAsString())) {
+        && !fields.contains(getEffectiveSchema(schema, parents).getFullPathAsString())) {
       return null;
     }
 
@@ -41,5 +41,17 @@ public class WithoutProperties implements SchemaVisitorTopDown<FeatureSchema, Fe
         .from(schema)
         .propertyMap(asMap(visitedProperties, FeatureSchema::getFullPathAsString))
         .build();
+  }
+
+  private FeatureSchema getEffectiveSchema(FeatureSchema schema, List<FeatureSchema> parents) {
+    if (!schema.isFeatureRef() && isFeatureRef(parents)) {
+      return parents.get(parents.size() - 1);
+    }
+
+    return schema;
+  }
+
+  private boolean isFeatureRef(List<FeatureSchema> parents) {
+    return !parents.isEmpty() && parents.get(parents.size() - 1).isFeatureRef();
   }
 }


### PR DESCRIPTION
If a FEATURE_REF property is included in a projection, the sub-properties of the FEATURE_REF object must be selected, too, not just the object-valued property.

Closes https://github.com/interactive-instruments/ldproxy/issues/1144.