### PR TITLE
fix removeSelect and reduceSelect

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaMapping.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaMapping.java
@@ -53,7 +53,10 @@ public interface SchemaMapping extends SchemaMappingBase<FeatureSchema> {
   @Override
   default List<FeatureSchema> getSchemas(
       List<String> path, List<FeatureSchema> schemas, boolean useTargetPaths) {
-    if (!useTargetPaths && schemas.stream().anyMatch(schema -> !schema.getCoalesce().isEmpty())) {
+    if (!useTargetPaths
+        && schemas.stream()
+            .anyMatch(
+                schema -> !schema.getCoalesce().isEmpty() && schema.getPropertyMap().isEmpty())) {
       return schemas.stream()
           .map(
               schema -> {

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaToPathsVisitor.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaToPathsVisitor.java
@@ -112,7 +112,8 @@ public class SchemaToPathsVisitor<T extends SchemaBase<T>>
     if (!useTargetPath
         && schema.getType() == Type.OBJECT_ARRAY
         && schema instanceof FeatureSchema
-        && !((FeatureSchema) schema).getConcat().isEmpty()) {
+        && (!((FeatureSchema) schema).getConcat().isEmpty()
+            || !((FeatureSchema) schema).getCoalesce().isEmpty())) {
       return Stream.concat(
               paths.stream().map(path -> Map.entry(path, schema)),
               visitedProperties.stream()

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTokenSliceTransformer.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTokenSliceTransformer.java
@@ -14,7 +14,7 @@ import de.ii.xtraplatform.features.domain.FeatureTokenType;
 import de.ii.xtraplatform.features.domain.SchemaBase.Type;
 import de.ii.xtraplatform.features.domain.Tuple;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -416,7 +416,7 @@ public interface FeaturePropertyTokenSliceTransformer
   }
 
   default Map<String, Integer> getValueIndexes(List<Object> slice, int from, int to) {
-    Map<String, Integer> valueIndexes = new HashMap<>();
+    Map<String, Integer> valueIndexes = new LinkedHashMap<>();
 
     for (int i = from; i < to; i++) {
       if (slice.get(i) == FeatureTokenType.VALUE) {
@@ -429,8 +429,25 @@ public interface FeaturePropertyTokenSliceTransformer
     return valueIndexes;
   }
 
+  default Map<String, Integer> getValueIndexesByProp(
+      List<Object> slice, int from, int to, int depth) {
+    Map<String, Integer> valueIndexes = new LinkedHashMap<>();
+
+    for (int i = from; i < to; i++) {
+      if (slice.get(i) == FeatureTokenType.VALUE) {
+        if (i + 2 < to
+            && slice.get(i + 1) instanceof List
+            && ((List<?>) slice.get(i + 1)).size() > depth) {
+          valueIndexes.put(((List<String>) slice.get(i + 1)).get(depth), i + 2);
+        }
+      }
+    }
+
+    return valueIndexes;
+  }
+
   default Map<String, Integer> getValueIndexesList(List<Object> slice, int from, int to) {
-    Map<String, Integer> valueIndexes = new HashMap<>();
+    Map<String, Integer> valueIndexes = new LinkedHashMap<>();
     int j = 0;
 
     for (int i = from; i < to; i++) {

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTokenSliceTransformer.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTokenSliceTransformer.java
@@ -459,6 +459,12 @@ public interface FeaturePropertyTokenSliceTransformer
         && Objects.equals(slice.get(index + 1), path);
   }
 
+  default boolean isNonNullValue(List<Object> slice, int index) {
+    return slice.get(index) == FeatureTokenType.VALUE
+        && index + 3 < slice.size()
+        && Objects.nonNull(slice.get(index + 2));
+  }
+
   default boolean isObjectWithPath(List<Object> slice, int index, List<String> path) {
     return slice.get(index) == FeatureTokenType.OBJECT
         && index + 1 < slice.size()

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
@@ -12,6 +12,7 @@ import de.ii.xtraplatform.features.domain.FeatureTokenType;
 import de.ii.xtraplatform.features.domain.SchemaBase.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import org.immutables.value.Value;
 
@@ -58,14 +59,9 @@ public abstract class FeaturePropertyTransformerCoalesce
       if (start > -1) {
         int end = findPos(slice, FeatureTokenType.OBJECT_END, rootPath, start);
 
-        transformed.addAll(slice.subList(start, end + 2));
+        return coalesceObjectProperties(slice, start + 2, end, rootPath);
       }
     } else {
-      /*int start = findPos(slice, FeatureTokenType.VALUE, rootPath, 0);
-
-      if (start > -1) {
-        transformed.addAll(slice.subList(start, start + 4));
-      }*/
       return coalesceValues(slice);
     }
 
@@ -97,6 +93,43 @@ public abstract class FeaturePropertyTransformerCoalesce
       if (!skip) {
         transformed.add(slice.get(i));
       }
+    }
+
+    return transformed;
+  }
+
+  private List<Object> coalesceObjectProperties(
+      List<Object> slice, int start, int end, List<String> rootPath) {
+    List<Object> transformed = new ArrayList<>();
+    boolean found = false;
+
+    Map<String, Integer> valueIndexes = getValueIndexesByProp(slice, start, end, rootPath.size());
+
+    for (int i = 0; i < schema.getCoalesce().size(); i++) {
+      String prefix = i + "_";
+      if (valueIndexes.keySet().stream().anyMatch(prop -> prop.startsWith(prefix))) {
+        valueIndexes.forEach(
+            (prop, index) -> {
+              if (prop.startsWith(prefix)) {
+                transformed.add(slice.get(index - 2));
+                transformed.add(slice.get(index - 1));
+                transformed.add(slice.get(index));
+                transformed.add(slice.get(index + 1));
+              }
+            });
+
+        // TODO: check if all required props are set, otherwise reset and continue
+
+        found = true;
+        break;
+      }
+    }
+
+    if (found) {
+      transformed.add(0, FeatureTokenType.OBJECT);
+      transformed.add(1, rootPath);
+      transformed.add(FeatureTokenType.OBJECT_END);
+      transformed.add(rootPath);
     }
 
     return transformed;

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
@@ -74,20 +74,25 @@ public abstract class FeaturePropertyTransformerCoalesce
 
   private List<Object> coalesceValues(List<Object> slice) {
     List<Object> transformed = new ArrayList<>();
-    boolean lastWasValueWithPath = false;
     boolean skip = false;
+    boolean found = false;
 
     for (int i = 0; i < slice.size(); i++) {
       if (isValueWithPath(slice, i, schema.getFullPath())) {
-        if (!lastWasValueWithPath && isNonNullValue(slice, i)) {
-          lastWasValueWithPath = true;
+        if (found) {
+          break;
+        }
+        if (isNonNullValue(slice, i)) {
           skip = false;
+          found = true;
         } else {
           skip = true;
         }
       } else if (slice.get(i) instanceof FeatureTokenType) {
-        lastWasValueWithPath = false;
-        skip = false;
+        if (found) {
+          break;
+        }
+        skip = true;
       }
       if (!skip) {
         transformed.add(slice.get(i));

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCoalesce.java
@@ -79,8 +79,9 @@ public abstract class FeaturePropertyTransformerCoalesce
 
     for (int i = 0; i < slice.size(); i++) {
       if (isValueWithPath(slice, i, schema.getFullPath())) {
-        if (!lastWasValueWithPath) {
+        if (!lastWasValueWithPath && isNonNullValue(slice, i)) {
           lastWasValueWithPath = true;
+          skip = false;
         } else {
           skip = true;
         }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerObjectReduceSelect.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerObjectReduceSelect.java
@@ -13,7 +13,6 @@ import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema.Builder;
 import de.ii.xtraplatform.features.domain.SchemaBase.Type;
 import de.ii.xtraplatform.features.domain.Tuple;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -32,10 +31,7 @@ public interface FeaturePropertyTransformerObjectReduceSelect
   default FeatureSchema transformSchema(FeatureSchema schema) {
     checkObject(schema);
 
-    Optional<FeatureSchema> selected =
-        schema.getProperties().stream()
-            .filter(property -> Objects.equals(property.getName(), getParameter()))
-            .findFirst();
+    Optional<FeatureSchema> selected = findProperty(schema, getParameter());
 
     if (selected.isEmpty()) {
       throw new IllegalArgumentException("Selected property not found: " + getParameter());

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerObjectRemoveSelect.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerObjectRemoveSelect.java
@@ -27,8 +27,7 @@ public interface FeaturePropertyTransformerObjectRemoveSelect
   default FeatureSchema transformSchema(FeatureSchema schema) {
     checkObject(schema);
 
-    if (schema.getProperties().stream()
-        .noneMatch(property -> Objects.equals(property.getName(), getParameter()))) {
+    if (findProperty(schema, getParameter()).isEmpty()) {
       throw new IllegalArgumentException("Selected property not found: " + getParameter());
     }
 
@@ -46,7 +45,7 @@ public interface FeaturePropertyTransformerObjectRemoveSelect
     String value = getValue(slice, getPropertyPath() + "." + getParameter(), start, end);
 
     if (Objects.nonNull(value)) {
-      result.addAll(slice);
+      result.addAll(slice.subList(start, end));
     }
   }
 }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeatureRefResolver.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeatureRefResolver.java
@@ -32,6 +32,8 @@ import java.util.stream.Stream;
  * - `title` is the title to use when presenting the link to a user, a `STRING`. The default value is the `id`, if the property is not specified.
  * - `type` is the feature type of the referenced feature in the same feature provider, a `STRING`.
  * </code>
+ *     <p>Limitations: These properties do not support transformations (e.g. `stringFormat`) or
+ *     `coalesce`.
  *     <p>#### Encoding feature references
  *     <p>When requested via the API, the feature reference can be encoded according to different
  *     profiles using the query parameter `profile` and depending on the negotiated feature format.
@@ -143,6 +145,8 @@ import java.util.stream.Stream;
  * - `title` ist die Bezeichnung, die verwendet wird, wenn der Link einem Benutzer angezeigt wird, ein `STRING`. Der Standardwert ist die `id`, wenn die Eigenschaft nicht angegeben wird.
  * - `type` ist die Objektart des referenzierten Features im selben Feature Provider, ein `STRING`.
  * </code>
+ *     <p>Einschränkungen: Diese Eigenschaften unterstützen keine Transformationen (z.B.
+ *     `stringFormat`) oder `coalesce`.
  *     <p>#### Kodieren von Objektreferenzen
  *     <p>Wenn Objekte über die API angefordert werden, können Objektreferenzen mit Hilfe des
  *     Abfrageparameters `profile` nach verschiedenen Profilen kodiert werden, je nach dem

--- a/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
+++ b/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
@@ -54,6 +54,7 @@ class TransformerSpec extends Specification {
         "object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
         "object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
         "object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
+        "value array coalesce"  | coalesce("hatObjekt", false)                           | "pfs_plan-hatObjekt-coalesce"        | "pfs_plan-hatObjekt"                 | "source2"   | "coalesce"
         "concat values"         | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
         "wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
         "reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
@@ -86,6 +87,10 @@ class TransformerSpec extends Specification {
 
     static Map<String, List<PropertyTransformation>> concat(String path, boolean isObject) {
         return [(path): [new ImmutablePropertyTransformation.Builder().concat(isObject).build()]]
+    }
+
+    static Map<String, List<PropertyTransformation>> coalesce(String path, boolean isObject) {
+        return [(path): [new ImmutablePropertyTransformation.Builder().coalesce(isObject).build()]]
     }
 
     static Map<String, List<PropertyTransformation>> arrayReduceFormat(String path, String template) {

--- a/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
+++ b/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
@@ -51,9 +51,9 @@ class TransformerSpec extends Specification {
         "wrap object"           | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | null         | "wrapped"
         "wrap object noop"      | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | "wrapped"    | "wrapped"
         "object array concat"   | concat("hatObjekt", true)                              | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "source"     | "concat"
-        "object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"])         | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
-        "object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}")                | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
-        "object array select"   | reduceSelect("hatObjekt", "1_id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
+        "object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
+        "object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
+        "object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
         "concat values"         | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
         "wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
         "reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
@@ -68,16 +68,16 @@ class TransformerSpec extends Specification {
         return [(path): [new ImmutablePropertyTransformation.Builder().wrap(type).build()]]
     }
 
-    static Map<String, List<PropertyTransformation>> mapFormat(String path, Map<String, String> map) {
-        return [(path): [new ImmutablePropertyTransformation.Builder().objectMapFormat(map).build()]]
+    static Map<String, List<PropertyTransformation>> mapFormat(String path, Map<String, String> map, String property) {
+        return [(path): [new ImmutablePropertyTransformation.Builder().objectRemoveSelect(property).objectMapFormat(map).build()]]
     }
 
-    static Map<String, List<PropertyTransformation>> reduceFormat(String path, String template) {
-        return [(path): [new ImmutablePropertyTransformation.Builder().objectReduceFormat(template).build()]]
+    static Map<String, List<PropertyTransformation>> reduceFormat(String path, String template, String property) {
+        return [(path): [new ImmutablePropertyTransformation.Builder().objectRemoveSelect(property).objectReduceFormat(template).build()]]
     }
 
     static Map<String, List<PropertyTransformation>> reduceSelect(String path, String property) {
-        return [(path): [new ImmutablePropertyTransformation.Builder().objectReduceSelect(property).build()]]
+        return [(path): [new ImmutablePropertyTransformation.Builder().objectRemoveSelect(property).objectReduceSelect(property).build()]]
     }
 
     static Map<String, List<PropertyTransformation>> duplicate(String path, Map<String, String> map) {

--- a/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
+++ b/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
@@ -46,19 +46,19 @@ class TransformerSpec extends Specification {
         where:
 
         casename                | transformations                                        | schema                               | tokens                               | sourceOnlyIf | targetOnlyIf
-        //"wrap value array"      | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | null         | "wrapped"
-        //"wrap value array noop" | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | "wrapped"    | "wrapped"
-        //"wrap object"           | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | null         | "wrapped"
-        //"wrap object noop"      | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | "wrapped"    | "wrapped"
+        "wrap value array"      | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | null         | "wrapped"
+        "wrap value array noop" | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | "wrapped"    | "wrapped"
+        "wrap object"           | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | null         | "wrapped"
+        "wrap object noop"      | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | "wrapped"    | "wrapped"
         "object array coalesce" | coalesce("hatObjekt", true, "id")                      | "pfs_plan-hatObjekt-coalesce"        | "pfs_plan-hatObjekt"                 | "source"     | "coalesce"
-        //"object array concat"   | concat("hatObjekt", true)                              | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "source"     | "concat"
-        //"object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
-        //"object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
-        //"object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
-        //"value array coalesce"  | coalesce("hatObjekt", false)                           | "pfs_plan-hatObjekt-value-coalesce"  | "pfs_plan-hatObjekt"                 | "source2"    | "coalesce2"
-        //"value array concat"    | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
-        //"wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
-        //"reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
+        "object array concat"   | concat("hatObjekt", true)                              | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "source"     | "concat"
+        "object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
+        "object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
+        "object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
+        "value array coalesce"  | coalesce("hatObjekt", false)                           | "pfs_plan-hatObjekt-value-coalesce"  | "pfs_plan-hatObjekt"                 | "source2"    | "coalesce2"
+        "value array concat"    | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
+        "wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
+        "reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
 
     }
 

--- a/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
+++ b/xtraplatform-features/src/test/groovy/de/ii/xtraplatform/features/domain/TransformerSpec.groovy
@@ -46,18 +46,19 @@ class TransformerSpec extends Specification {
         where:
 
         casename                | transformations                                        | schema                               | tokens                               | sourceOnlyIf | targetOnlyIf
-        "wrap value array"      | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | null         | "wrapped"
-        "wrap value array noop" | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | "wrapped"    | "wrapped"
-        "wrap object"           | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | null         | "wrapped"
-        "wrap object noop"      | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | "wrapped"    | "wrapped"
-        "object array concat"   | concat("hatObjekt", true)                              | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "source"     | "concat"
-        "object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
-        "object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
-        "object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
-        "value array coalesce"  | coalesce("hatObjekt", false)                           | "pfs_plan-hatObjekt-coalesce"        | "pfs_plan-hatObjekt"                 | "source2"   | "coalesce"
-        "concat values"         | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
-        "wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
-        "reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
+        //"wrap value array"      | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | null         | "wrapped"
+        //"wrap value array noop" | wrap("hatGenerAttribut.wert", VALUE_ARRAY)             | "bp_anpflanzungbindungerhaltung-min" | "bp_anpflanzungbindungerhaltung-min" | "wrapped"    | "wrapped"
+        //"wrap object"           | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | null         | "wrapped"
+        //"wrap object noop"      | wrap("gehoertZuPlan", OBJECT)                          | "bp_bereich-min"                     | "bp_bereich"                         | "wrapped"    | "wrapped"
+        "object array coalesce" | coalesce("hatObjekt", true, "id")                      | "pfs_plan-hatObjekt-coalesce"        | "pfs_plan-hatObjekt"                 | "source"     | "coalesce"
+        //"object array concat"   | concat("hatObjekt", true)                              | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "source"     | "concat"
+        //"object array format"   | mapFormat("hatObjekt", ["href": "id::{{id}}"], "id")   | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "mapped"
+        //"object array reduce"   | reduceFormat("hatObjekt", "id::{{id}}", "id")          | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "reduced"
+        //"object array select"   | reduceSelect("hatObjekt", "id")                        | "pfs_plan-hatObjekt"                 | "pfs_plan-hatObjekt"                 | "concat"     | "selected"
+        //"value array coalesce"  | coalesce("hatObjekt", false)                           | "pfs_plan-hatObjekt-value-coalesce"  | "pfs_plan-hatObjekt"                 | "source2"    | "coalesce2"
+        //"value array concat"    | concat("process.title", false)                         | "observation"                        | "observation"                        | "source"     | "concat"
+        //"wrap value array"      | wrap("process.title", VALUE_ARRAY)                     | "observation"                        | "observation"                        | "concat"     | "wrapped"
+        //"reduce value array"    | arrayReduceFormat("process.title", "{{0}} nach {{1}}") | "observation"                        | "observation"                        | "wrapped"    | "reduced"
 
     }
 
@@ -87,6 +88,10 @@ class TransformerSpec extends Specification {
 
     static Map<String, List<PropertyTransformation>> concat(String path, boolean isObject) {
         return [(path): [new ImmutablePropertyTransformation.Builder().concat(isObject).build()]]
+    }
+
+    static Map<String, List<PropertyTransformation>> coalesce(String path, boolean isObject, String property) {
+        return [(path): [new ImmutablePropertyTransformation.Builder().objectRemoveSelect(property).coalesce(isObject).build()]]
     }
 
     static Map<String, List<PropertyTransformation>> coalesce(String path, boolean isObject) {

--- a/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-coalesce.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-coalesce.yml
@@ -1,0 +1,23 @@
+# schema references, mapping operations and feature refs are already resolved
+sourcePath: "/pfs_plan"
+type: OBJECT
+objectType: PFS_Plan
+properties:
+  oid:
+    sourcePath: id
+    type: STRING
+    role: ID
+  hatObjekt:
+    type: VALUE_ARRAY
+    valueType: INTEGER
+    sourcePaths:
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
+    coalesce:
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
+        type: INTEGER
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
+        type: INTEGER
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
+        type: INTEGER

--- a/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-coalesce.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-coalesce.yml
@@ -8,16 +8,62 @@ properties:
     type: STRING
     role: ID
   hatObjekt:
-    type: VALUE_ARRAY
-    valueType: INTEGER
+    type: OBJECT_ARRAY
+    refType: DYNAMIC
     sourcePaths:
-      - '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
-      - '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
-      - '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss'
+    properties:
+      1_type:
+        type: STRING
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/constant_hatObjekt_37{constant=bst_erdgasleitung}'
+      1_id:
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
+        type: INTEGER
+      1_title:
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/text'
+        type: STRING
+      2_type:
+        type: STRING
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/constant_hatObjekt_38{constant=bst_speicher}'
+      2_id:
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
+        type: INTEGER
+      2_title:
+        sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/text'
+        type: STRING
     coalesce:
-      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
-        type: INTEGER
-      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
-        type: INTEGER
-      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
-        type: INTEGER
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung'
+        properties:
+          type:
+            type: STRING
+            constantValue: bst_erdgasleitung
+          id:
+            sourcePath: _id
+            type: INTEGER
+          title:
+            sourcePath: text
+            type: STRING
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher'
+        properties:
+          type:
+            type: STRING
+            constantValue: bst_speicher
+          id:
+            sourcePath: _id
+            type: INTEGER
+          title:
+            sourcePath: text
+            type: STRING
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss'
+        properties:
+          type:
+            type: STRING
+            constantValue: bst_hausanschluss
+          id:
+            sourcePath: _id
+            type: INTEGER
+          title:
+            sourcePath: text
+            type: STRING

--- a/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-value-coalesce.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-schemas/pfs_plan-hatObjekt-value-coalesce.yml
@@ -1,0 +1,23 @@
+# schema references, mapping operations and feature refs are already resolved
+sourcePath: "/pfs_plan"
+type: OBJECT
+objectType: PFS_Plan
+properties:
+  oid:
+    sourcePath: id
+    type: STRING
+    role: ID
+  hatObjekt:
+    type: VALUE_ARRAY
+    valueType: INTEGER
+    sourcePaths:
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
+      - '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
+    coalesce:
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id'
+        type: INTEGER
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id'
+        type: INTEGER
+      - sourcePath: '[_id=gehoertzuplan_pfs_plan_fk]bst_hausanschluss/_id'
+        type: INTEGER

--- a/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
@@ -7,6 +7,10 @@ tokens:
   - type: ARRAY
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
+  - type: ARRAY
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
+    target: hatObjekt
+    onlyIf: source2
   - type: OBJECT
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
@@ -40,6 +44,7 @@ tokens:
     valueType: STRING
     onlyIf: reduced
   - type: VALUE
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
     target: hatObjekt
     value: 1
     valueType: INTEGER
@@ -81,6 +86,7 @@ tokens:
     valueType: STRING
     onlyIf: reduced
   - type: VALUE
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
     target: hatObjekt
     value: 2
     valueType: INTEGER
@@ -119,6 +125,12 @@ tokens:
     value: Speicher Nüttemoor
     valueType: STRING
     onlyIf: source,concat
+  - type: VALUE
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id
+    target: hatObjekt
+    value: null
+    valueType: INTEGER
+    onlyIf: source2
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
@@ -156,14 +168,19 @@ tokens:
     valueType: STRING
     onlyIf: reduced
   - type: VALUE
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
     target: hatObjekt
     value: 2
     valueType: INTEGER
-    onlyIf: selected
+    onlyIf: selected,source2,coalesce
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
     onlyIf: source,concat,mapped
   - type: ARRAY_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
+    target: hatObjekt
+  - type: ARRAY_END
+    onlyIf: source2
+    source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id
     target: hatObjekt

--- a/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
@@ -7,6 +7,7 @@ tokens:
   - type: ARRAY
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
+    onlyIf: source,concat,mapped,selected,reduced
   - type: ARRAY
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
     target: hatObjekt
@@ -14,25 +15,25 @@ tokens:
   - type: OBJECT
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
-    onlyIf: source,concat,mapped
+    onlyIf: source,concat,coalesce,mapped
   - type: VALUE
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/_id
     target: hatObjekt.1_id
     value: 1
     valueType: INTEGER
-    onlyIf: source,concat
+    onlyIf: source,concat,coalesce
   - type: VALUE
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/constant_hatObjekt_37
     target: hatObjekt.1_type
     value: bst_erdgasleitung
     valueType: STRING
-    onlyIf: source,concat
+    onlyIf: source,concat,coalesce
   - type: VALUE
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung/text
     target: hatObjekt.1_title
     value: WAL
     valueType: STRING
-    onlyIf: source,concat
+    onlyIf: source,concat,coalesce
   - type: VALUE
     target: hatObjekt.href
     value: id::1
@@ -52,7 +53,7 @@ tokens:
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
-    onlyIf: source,concat,mapped
+    onlyIf: source,concat,coalesce,mapped
   - type: OBJECT
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_erdgasleitung
     target: hatObjekt
@@ -172,7 +173,7 @@ tokens:
     target: hatObjekt
     value: 2
     valueType: INTEGER
-    onlyIf: selected,source2,coalesce
+    onlyIf: selected,source2,coalesce2
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
@@ -180,6 +181,7 @@ tokens:
   - type: ARRAY_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
+    onlyIf: source,concat,mapped,selected,reduced
   - type: ARRAY_END
     onlyIf: source2
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id

--- a/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
+++ b/xtraplatform-features/src/testFixtures/resources/feature-tokens/pfs_plan-hatObjekt.yml
@@ -100,11 +100,11 @@ tokens:
   - type: OBJECT
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
-    onlyIf: source,concat,mapped
+    onlyIf: source,concat
   - type: VALUE
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher/_id
     target: hatObjekt.2_id
-    value: 1
+    value: null
     valueType: INTEGER
     onlyIf: source,concat
   - type: VALUE
@@ -119,24 +119,10 @@ tokens:
     value: Speicher Nüttemoor
     valueType: STRING
     onlyIf: source,concat
-  - type: VALUE
-    target: hatObjekt.href
-    value: id::1
-    valueType: STRING
-    onlyIf: mapped
-  - type: VALUE
-    target: hatObjekt
-    value: id::1
-    valueType: STRING
-    onlyIf: reduced
-  - type: VALUE
-    target: hatObjekt
-    valueType: STRING
-    onlyIf: selected
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
-    onlyIf: source,concat,mapped
+    onlyIf: source,concat
   - type: OBJECT
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher
     target: hatObjekt
@@ -171,7 +157,8 @@ tokens:
     onlyIf: reduced
   - type: VALUE
     target: hatObjekt
-    valueType: STRING
+    value: 2
+    valueType: INTEGER
     onlyIf: selected
   - type: OBJECT_END
     source: /pfs_plan/[_id=gehoertzuplan_pfs_plan_fk]bst_speicher


### PR DESCRIPTION
I think the original approach in `FeaturePropertyTransformerObjectRemoveSelect` was correct, the only bug was that it added the whole slice to the result and ignored start and end.
Apart from that there were some general issues in `FeaturePropertyTokenSliceTransformer` that also affected `objectReduceSelect`.
I also added some cases with `objectRemoveSelect` to the unit tests.

If this does not work you, I would need the specific use case.