### PR TITLE
MBTiles Cache: Additional improvements

### DIFF
--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileEncoderMvt.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileEncoderMvt.java
@@ -53,6 +53,15 @@ public class TileEncoderMvt implements TileEncoder {
       TileQuery tileQuery = ImmutableTileQuery.builder().from(tile).tileset(tileset).build();
       TileResult layer = tileProvider.get(tileQuery);
 
+      int count = 1;
+      while (layer.isError() && count++ < 3) {
+        try {
+          Thread.sleep(100);
+        } catch (Throwable ignore) {
+        }
+        layer = tileProvider.get(tileQuery);
+      }
+
       if (layer.isError()) {
         if (LOGGER.isWarnEnabled()) {
           LOGGER.warn(

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileStoreMbTiles.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/app/TileStoreMbTiles.java
@@ -210,11 +210,13 @@ public class TileStoreMbTiles implements TileStore {
     MbtilesTileset tileset = tileSets.get(key(tile));
     boolean written = false;
     int count = 0;
+    String reason = null;
     while (!written && count++ < 3) {
       try {
         tileset.writeTile(tile, content.readAllBytes());
         written = true;
       } catch (SQLException e) {
+        reason = e.getMessage();
         if (LOGGER.isTraceEnabled()) {
           LOGGER.trace(
               "Failed to write tile {}/{}/{}/{} for tileset '{}'. Reason: {}. Trying again...",
@@ -223,7 +225,7 @@ public class TileStoreMbTiles implements TileStore {
               tile.getRow(),
               tile.getCol(),
               tile.getTileset(),
-              e.getMessage());
+              reason);
         }
         try {
           Thread.sleep(100);
@@ -236,12 +238,13 @@ public class TileStoreMbTiles implements TileStore {
     if (!written) {
       if (LOGGER.isWarnEnabled()) {
         LOGGER.warn(
-            "Failed to write tile {}/{}/{}/{} for tileset '{}'.",
+            "Failed to write tile {}/{}/{}/{} for tileset '{}'. Reason: {}.",
             tile.getTileMatrixSet().getId(),
             tile.getLevel(),
             tile.getRow(),
             tile.getCol(),
-            tile.getTileset());
+            tile.getTileset(),
+            reason);
       }
     }
   }

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/MbtilesTileset.java
@@ -92,7 +92,7 @@ public class MbtilesTileset {
       SqlHelper.execute(connection, "PRAGMA journal_mode=WAL");
       SqlHelper.execute(connection, "PRAGMA temp_store=MEMORY");
       SqlHelper.execute(connection, "PRAGMA locking_mode=EXCLUSIVE");
-      SqlHelper.execute(connection, "PRAGMA synchronous=OFF");
+      SqlHelper.execute(connection, "PRAGMA synchronous=NORMAL");
       // create tables and views
       SqlHelper.execute(connection, "BEGIN TRANSACTION IMMEDIATE");
       SqlHelper.execute(connection, "CREATE TABLE metadata (name text, value text)");


### PR DESCRIPTION
This is a follow-up to #260:

- In addition to failure when writing a tile during seeding, SQL errors when reading a tile during seeding are now also caught and only result in a log entry, but these do not stop the seeding thread.
- When writing a tile fails repeatedly, the message from the last failed attempt is written to the log.