### PR TITLE
fix labelTemplate

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
@@ -282,7 +282,7 @@ public class FeatureProviderSqlFactory
   }
 
   private FeatureProviderSqlData applyLabelTemplate(FeatureProviderSqlData data) {
-    if (data.getLabelTemplate().isPresent()) {
+    if (data.getLabelTemplate().isPresent() && !"{{value}}".equals(data.getLabelTemplate().get())) {
 
       Map<String, FeatureSchema> types =
           data.getTypes().entrySet().stream()

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
@@ -8,7 +8,6 @@
 package de.ii.xtraplatform.features.sql.domain;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.collect.ImmutableMap;
 import de.ii.xtraplatform.docs.DocIgnore;
 import de.ii.xtraplatform.docs.DocMarker;
 import de.ii.xtraplatform.entities.domain.EntityDataBuilder;
@@ -18,14 +17,8 @@ import de.ii.xtraplatform.features.domain.ExtensionConfiguration;
 import de.ii.xtraplatform.features.domain.FeatureProviderDataV2;
 import de.ii.xtraplatform.features.domain.FeatureSchema;
 import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema;
-import de.ii.xtraplatform.features.domain.SchemaVisitorTopDown;
 import de.ii.xtraplatform.features.domain.WithConnectionInfo;
-import de.ii.xtraplatform.strings.domain.StringTemplateFilters;
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -104,53 +97,6 @@ public interface FeatureProviderSqlData
       return new ImmutableFeatureProviderSqlData.Builder()
           .from(this)
           .extensions(distinctExtensions)
-          .build();
-    }
-
-    return this;
-  }
-
-  @Value.Check
-  default FeatureProviderSqlData applyLabelTemplate() {
-    if (getLabelTemplate().isPresent()) {
-
-      Map<String, FeatureSchema> types =
-          getTypes().entrySet().stream()
-              .map(
-                  entry ->
-                      new SimpleImmutableEntry<>(
-                          entry.getKey(),
-                          entry
-                              .getValue()
-                              .accept(
-                                  (SchemaVisitorTopDown<FeatureSchema, FeatureSchema>)
-                                      (schema, parents, visitedProperties) -> {
-                                        ImmutableFeatureSchema.Builder builder =
-                                            new ImmutableFeatureSchema.Builder().from(schema);
-                                        visitedProperties.forEach(
-                                            prop -> builder.putPropertyMap(prop.getName(), prop));
-                                        if (schema.getLabel().isPresent()) {
-                                          Map<String, String> lookup = new HashMap<>();
-                                          schema
-                                              .getLabel()
-                                              .ifPresent(label -> lookup.put("value", label));
-                                          schema
-                                              .getUnit()
-                                              .ifPresent(unit -> lookup.put("unit", unit));
-
-                                          builder.label(
-                                              StringTemplateFilters.applyTemplate(
-                                                  getLabelTemplate().get(), lookup::get));
-                                        }
-
-                                        return builder.build();
-                                      })))
-              .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
-
-      return new ImmutableFeatureProviderSqlData.Builder()
-          .from(this)
-          .types(types)
-          .labelTemplate(Optional.empty())
           .build();
     }
 

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderDataV2.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderDataV2.java
@@ -97,7 +97,21 @@ public interface FeatureProviderDataV2 extends ProviderData, AutoEntity, Extenda
   @Nullable
   MODE getTypeValidation();
 
-  @DocIgnore
+  /**
+   * @langEn A template for schema labels. By default, the label set in the schema is used - or the
+   *     name, if no label is set. The template is a string template and can contain the variables
+   *     `{{value}}` for the schema label and `{{unit}}` for the unit declared in the schema. For
+   *     example, to append the unit of measure in square brackets to the property label, one can
+   *     use `{{value}}{{unit | prepend:' [' | append:']'}}`. This option is only supported in the
+   *     SQL feature provider.
+   * @langDe Ein Template für Labels im Schema. Standardmäßig wird das im Schema festgelegte Label
+   *     verwendet - oder der Name, wenn kein Label festgelegt ist. Die Vorlage ist eine
+   *     String-Vorlage und kann die Variablen `{{Wert}}` für die Schemabezeichnung und `{Einheit}}`
+   *     für die im Schema deklarierte Maßeinheit enthalten. Um zum Beispiel die Einheit in eckigen
+   *     Klammern an das Label einer Property anzuhängen, kann man `{{value}}{{unit | prepend:' [' |
+   *     append:']'}}` verwenden. Diese Option wird nur im SQL Feature-Provider unterstützt.
+   * @default `{{value}}`
+   */
   Optional<String> getLabelTemplate();
 
   /**


### PR DESCRIPTION
This change fixes two issues:

- The label template was only applied, if there was an explicit label that differs from the name. It is now always applied, using the name as the default label.
- The label template was not applied on properties in `fragments`. This is addressed by moving the schema transformation after resolving the schemas. So far the labelTemplate transformer was the only transformer applied in `FeatureProviderSqlData` while all the other transformers are applied in `FeatureProviderSqlFactory`.

In addition, after the schema resolver transformation has been applied, the fragments are no longer used and can be removed from the data.

This is an undocumented option. Shouldn't the option be documented?

Closes https://github.com/interactive-instruments/ldproxy/issues/1259