### PR TITLE
fix maxAllowableOffset

### DIFF
--- a/xtraplatform-crs/src/main/java/de/ii/xtraplatform/crs/infra/CrsTransformerProj.java
+++ b/xtraplatform-crs/src/main/java/de/ii/xtraplatform/crs/infra/CrsTransformerProj.java
@@ -64,8 +64,8 @@ public class CrsTransformerProj extends BoundingBoxTransformer implements CrsTra
     SingleCRS horizontalSourceCrs = getHorizontalCrs(sourceCrs);
     SingleCRS horizontalTargetCrs = getHorizontalCrs(targetCrs);
 
-    this.sourceUnitEquivalentInMeters = getUnitEquivalentInMeters(horizontalSourceCrs);
-    this.targetUnitEquivalentInMeters = getUnitEquivalentInMeters(horizontalTargetCrs);
+    this.sourceUnitEquivalentInMeters = getUnitEquivalentInMeters(horizontalSourceCrs, true);
+    this.targetUnitEquivalentInMeters = getUnitEquivalentInMeters(horizontalTargetCrs, false);
 
     this.sourceDimension = sourceDimension;
     this.targetDimension = targetDimension;
@@ -144,8 +144,9 @@ public class CrsTransformerProj extends BoundingBoxTransformer implements CrsTra
     return coordinateOperation.getMathTransform();
   }
 
-  private double getUnitEquivalentInMeters(SingleCRS horizontalCrs) {
-    return isSourceMetric || !(horizontalCrs.getDatum() instanceof GeodeticDatum)
+  private double getUnitEquivalentInMeters(SingleCRS horizontalCrs, boolean isSource) {
+    return (isSource ? isSourceMetric : isTargetMetric)
+            || !(horizontalCrs.getDatum() instanceof GeodeticDatum)
         ? 1
         : (Math.PI / 180.00)
             * ((GeodeticDatum) horizontalCrs.getDatum()).getEllipsoid().getSemiMajorAxis();

--- a/xtraplatform-geometries/src/main/java/de/ii/xtraplatform/geometries/domain/CoordinatesTransformer.java
+++ b/xtraplatform-geometries/src/main/java/de/ii/xtraplatform/geometries/domain/CoordinatesTransformer.java
@@ -70,7 +70,7 @@ public abstract class CoordinatesTransformer extends Writer {
       return getMaxAllowableOffset() * requestFactor;
     }
 
-    return getMaxAllowableOffset();
+    return getMaxAllowableOffset() * requestFactor / localFactor;
   }
 
   @Value.Derived


### PR DESCRIPTION
For cases, where source and target CRS use a different unit, maxAllowableOffset was not applied correctly.

Example: the native CRS is metric and requested CRS is CRS84, e.g., the `strassen` API. A sample request is https://demo.ldproxy.net/strassen/collections/abschnitteaeste/items/3712041O3713038A?maxAllowableOffset=1, where the value should be treated as 1°, but 1m is applied.