### PR TITLE
Advanced SQL

### DIFF
--- a/xtraplatform-features-json/src/main/java/de/ii/xtraplatform/features/json/app/DecoderFactoryJson.java
+++ b/xtraplatform-features-json/src/main/java/de/ii/xtraplatform/features/json/app/DecoderFactoryJson.java
@@ -8,6 +8,7 @@
 package de.ii.xtraplatform.features.json.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.xtraplatform.base.domain.util.Tuple;
 import de.ii.xtraplatform.features.domain.Decoder;
 import de.ii.xtraplatform.features.domain.DecoderFactory;
 import de.ii.xtraplatform.features.json.domain.DecoderJson;
@@ -29,7 +30,24 @@ public class DecoderFactoryJson implements DecoderFactory {
   }
 
   @Override
+  public Optional<String> getConnectorString() {
+    return Optional.of("JSON");
+  }
+
+  @Override
   public Decoder createDecoder() {
     return new DecoderJson(Optional.empty());
+  }
+
+  @Override
+  public Tuple<String, String> parseSourcePath(
+      String path, String column, String flags, String connectorSpec) {
+    String pathInConnector = path.substring(path.indexOf(connectorSpec) + connectorSpec.length());
+
+    if (!pathInConnector.isEmpty()) {
+      return Tuple.of(column, pathInConnector.substring(1).replace('/', '.'));
+    }
+
+    return Tuple.of(column, "");
   }
 }

--- a/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/FeatureProviderOracle.java
+++ b/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/FeatureProviderOracle.java
@@ -36,6 +36,7 @@ import de.ii.xtraplatform.features.sql.domain.SqlQueryOptions;
 import de.ii.xtraplatform.features.sql.domain.SqlRow;
 import de.ii.xtraplatform.streams.domain.Reactive;
 import de.ii.xtraplatform.values.domain.ValueStore;
+import java.util.Map;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,7 +140,8 @@ public class FeatureProviderOracle extends FeatureProviderSql {
         decoderFactories,
         volatileRegistry,
         cache,
-        data);
+        data,
+        Map.of());
   }
 
   @Override

--- a/xtraplatform-features-sql/build.gradle
+++ b/xtraplatform-features-sql/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     embeddedFlatExport libs.sqlite
 
     testImplementation 'de.interactive_instruments:xtraplatform-proj'
+    testImplementation project(":xtraplatform-features-json")
     testImplementation(testFixtures(project(":xtraplatform-cql")))
     testImplementation(testFixtures(project(":xtraplatform-features")))
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
@@ -23,7 +23,8 @@ import javax.ws.rs.core.MediaType;
 @AutoBind
 public class DecoderFactorySqlExpression implements DecoderFactory {
 
-  public static final MediaType MEDIA_TYPE = MediaType.valueOf("application/vnd.ldproxy.sql-expression");
+  public static final MediaType MEDIA_TYPE =
+      MediaType.valueOf("application/vnd.ldproxy.sql-expression");
   public static final String CONNECTOR_STRING = "EXPRESSION";
   private static final Pattern SQL_FLAG = Pattern.compile("\\{sql=(?<SQL>.+?)\\}");
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.MediaType;
 @AutoBind
 public class DecoderFactorySqlExpression implements DecoderFactory {
 
-  public static final MediaType MEDIA_TYPE = MediaType.valueOf("application/sql+expression");
+  public static final MediaType MEDIA_TYPE = MediaType.valueOf("application/vnd.ldproxy.sql-expression");
   public static final String CONNECTOR_STRING = "EXPRESSION";
   private static final Pattern SQL_FLAG = Pattern.compile("\\{sql=(?<SQL>.+?)\\}");
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/DecoderFactorySqlExpression.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.sql.app;
+
+import com.github.azahnen.dagger.annotations.AutoBind;
+import de.ii.xtraplatform.base.domain.util.Tuple;
+import de.ii.xtraplatform.features.domain.Decoder;
+import de.ii.xtraplatform.features.domain.DecoderFactory;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.core.MediaType;
+
+@Singleton
+@AutoBind
+public class DecoderFactorySqlExpression implements DecoderFactory {
+
+  public static final MediaType MEDIA_TYPE = MediaType.valueOf("application/sql+expression");
+  public static final String CONNECTOR_STRING = "EXPRESSION";
+  private static final Pattern SQL_FLAG = Pattern.compile("\\{sql=(?<SQL>.+?)\\}");
+
+  private final AtomicInteger expressionCounter = new AtomicInteger(0);
+
+  @Inject
+  public DecoderFactorySqlExpression() {}
+
+  @Override
+  public MediaType getMediaType() {
+    return MEDIA_TYPE;
+  }
+
+  @Override
+  public Optional<String> getConnectorString() {
+    return Optional.of(CONNECTOR_STRING);
+  }
+
+  @Override
+  public Decoder createDecoder() {
+    return Decoder.noop();
+  }
+
+  @Override
+  public Tuple<String, String> parseSourcePath(
+      String path, String column, String flags, String connectorSpec) {
+    Matcher matcher = SQL_FLAG.matcher(flags);
+
+    if (matcher.find()) {
+      return Tuple.of(
+          String.format("SQL__%s", expressionCounter.incrementAndGet()), matcher.group("SQL"));
+    }
+
+    return DecoderFactory.super.parseSourcePath(path, column, flags, connectorSpec);
+  }
+}

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureDecoderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureDecoderSql.java
@@ -8,6 +8,7 @@
 package de.ii.xtraplatform.features.sql.app;
 
 import de.ii.xtraplatform.features.domain.Decoder;
+import de.ii.xtraplatform.features.domain.DecoderFactory;
 import de.ii.xtraplatform.features.domain.FeatureEventHandler;
 import de.ii.xtraplatform.features.domain.FeatureEventHandler.ModifiableContext;
 import de.ii.xtraplatform.features.domain.FeatureQuery;
@@ -29,7 +30,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +46,7 @@ public class FeatureDecoderSql
   private final List<List<String>> mainTablePaths;
   private final FeatureStoreMultiplicityTracker multiplicityTracker;
   private final boolean isSingleFeature;
-  private final Map<String, Supplier<Decoder>> subDecoderFactories;
+  private final Map<String, DecoderFactory> subDecoderFactories;
   private final Map<String, Decoder> subDecoders;
 
   private boolean started;
@@ -62,7 +62,7 @@ public class FeatureDecoderSql
       Map<String, SchemaMapping> mappings,
       List<SchemaSql> tableSchemas,
       Query query,
-      Map<String, Supplier<Decoder>> subDecoderFactories) {
+      Map<String, DecoderFactory> subDecoderFactories) {
     this.mappings = mappings;
     this.query = query;
 
@@ -89,7 +89,8 @@ public class FeatureDecoderSql
         new NestingTracker(getDownstream(), context, mainTablePaths, false, false, false);
 
     // TODO: pass context and downstream
-    subDecoderFactories.forEach((connector, factory) -> subDecoders.put(connector, factory.get()));
+    subDecoderFactories.forEach(
+        (connector, factory) -> subDecoders.put(connector, factory.createDecoder()));
   }
 
   @Override

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
@@ -221,6 +221,12 @@ public class SqlQueryTemplatesDeriver
                               return sqlDialect.applyToDate(name, column.getFormat());
                             return sqlDialect.applyToDatetime(name, column.getFormat());
                           }
+                          if (column.isExpression()) {
+                            return sqlDialect.applyToExpression(
+                                attributeContainerAlias,
+                                column.getName(),
+                                column.getSubDecoderPaths());
+                          }
 
                           return name;
                         }))

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -180,6 +180,8 @@ import org.threeten.extra.Interval;
  *     table from the parent object, `fk` is the foreign key of the joining table and `tab` is the
  *     name of the joining table. Example from above: `[oid=kita_fk]plaetze`. When a junction table
  *     should be used, two such joins are concatenated with "/", e.g. `[id=fka]a_2_b/[fkb=id]tab_b`.
+ *     To use a different join type than the default `INNER`, for example `{joinType=LEFT}` can be
+ *     appended to the join expression
  *     <p>Rows for a table can be filtered by adding `{filter=expression}` after the table name,
  *     where `expression` is a [CQL2 Text](https://docs.ogc.org/is/21-065r1/21-065r1.html#cql2-text)
  *     expression. For details see the building block [Filter /
@@ -191,6 +193,9 @@ import org.threeten.extra.Interval;
  *     <p>A non-default sort key can be set by adding `{sortKey=columnName}` after the table name.
  *     If that sort key is not unique, add `{sortKeyUnique=false}`.
  *     <p>All table and column names must be unquoted identifiers.
+ *     <p>Arbitrary SQL expressions for values are supported, for example to apply function calls.
+ *     As an example, this `[EXPRESSION]{sql=$T$.length+55.5}` (instead of just `length`) would add
+ *     a fixed amount to the length column. The prefix `$T$` will be replaced with the table alias.
  *     <p>### Query Generation
  *     <p>Options for query generation.
  *     <p>{@docTable:queryGeneration}
@@ -218,7 +223,9 @@ import org.threeten.extra.Interval;
  *     Tabelle aus dem übergeordneten Schemaobjekt ist, `fk` der Fremdschlüssel aus der über den
  *     Join angebundenen Tabelle und `tab` der Tabellenname. Siehe `[oid=kita_fk]plaetze` in dem
  *     Beispiel oben. Bei der Verwendung einer Zwischentabelle werden zwei dieser Joins
- *     aneinandergehängt, z.B. `[id=fka]a_2_b/[fkb=id]tab_b`.
+ *     aneinandergehängt, z.B. `[id=fka]a_2_b/[fkb=id]tab_b`. Um einen anderen als den
+ *     Standard-Join-Typ `INNER` zu werden, kann z.B. `{joinType=LEFT}` nach dem Join-Ausdruck
+ *     angegeben werden.
  *     <p>Auf einer Tabelle (der Haupttabelle eines Features oder einer über Join-angebundenen
  *     Tabelle) kann zusätzlich ein einschränkender Filter durch den Zusatz `{filter=ausdruck}`
  *     angegeben werden, wobei `ausdruck` das Selektionskriertium in [CQL2
@@ -234,6 +241,10 @@ import org.threeten.extra.Interval;
  *     <p>Ein vom Standard abweichender `primaryKey` kann durch den Zusatz von
  *     `{primaryKey=Spaltenname}` nach dem Tabellennamen angegeben werden.
  *     <p>Alle Tabellen- und Spaltennamen müssen "unquoted Identifier" sein.
+ *     <p>Beliebige SQL-Ausdrücke für Werte sind möglich, z.B. um Funktionsaufrufe anzuwenden. So
+ *     würde z.B. dieser Ausdruck `[EXPRESSION]{sql=$T$.length+55.5}` (anstatt nur `length`) einen
+ *     fixen Wert zur Längen-Spalte addieren. Der Präfix `$T$` wird durch den Tabellen-Alias
+ *     ersetzt.
  *     <p>### Query-Generierung
  *     <p>Optionen für die Query-Generierung in `queryGeneration`.
  *     <p>{@docTable:queryGeneration}

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -1235,7 +1235,7 @@ public class FeatureProviderSql
   @Override
   public FeatureSchema getQueryablesSchema(
       FeatureSchema schema, List<String> included, List<String> excluded, String pathSeparator) {
-    Predicate<String> excludeConnectors = path -> path.matches(".+?\\[[^=\\]]+].+");
+    Predicate<String> excludeConnectors = path -> path.matches(".*?\\[[^=\\]]+].+");
     OnlyQueryables queryablesSelector =
         new OnlyQueryables(included, excluded, pathSeparator, excludeConnectors);
 
@@ -1245,7 +1245,7 @@ public class FeatureProviderSql
   @Override
   public FeatureSchema getSortablesSchema(
       FeatureSchema schema, List<String> included, List<String> excluded, String pathSeparator) {
-    Predicate<String> excludeConnectors = path -> path.matches(".+?\\[[^=\\]]+].+");
+    Predicate<String> excludeConnectors = path -> path.matches(".*?\\[[^=\\]]+].+");
     OnlySortables sortablesSelector =
         new OnlySortables(included, excluded, pathSeparator, excludeConnectors);
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -180,8 +180,6 @@ import org.threeten.extra.Interval;
  *     table from the parent object, `fk` is the foreign key of the joining table and `tab` is the
  *     name of the joining table. Example from above: `[oid=kita_fk]plaetze`. When a junction table
  *     should be used, two such joins are concatenated with "/", e.g. `[id=fka]a_2_b/[fkb=id]tab_b`.
- *     To use a different join type than the default `INNER`, for example `{joinType=LEFT}` can be
- *     appended to the join expression
  *     <p>Rows for a table can be filtered by adding `{filter=expression}` after the table name,
  *     where `expression` is a [CQL2 Text](https://docs.ogc.org/is/21-065r1/21-065r1.html#cql2-text)
  *     expression. For details see the building block [Filter /
@@ -223,9 +221,7 @@ import org.threeten.extra.Interval;
  *     Tabelle aus dem übergeordneten Schemaobjekt ist, `fk` der Fremdschlüssel aus der über den
  *     Join angebundenen Tabelle und `tab` der Tabellenname. Siehe `[oid=kita_fk]plaetze` in dem
  *     Beispiel oben. Bei der Verwendung einer Zwischentabelle werden zwei dieser Joins
- *     aneinandergehängt, z.B. `[id=fka]a_2_b/[fkb=id]tab_b`. Um einen anderen als den
- *     Standard-Join-Typ `INNER` zu werden, kann z.B. `{joinType=LEFT}` nach dem Join-Ausdruck
- *     angegeben werden.
+ *     aneinandergehängt, z.B. `[id=fka]a_2_b/[fkb=id]tab_b`.
  *     <p>Auf einer Tabelle (der Haupttabelle eines Features oder einer über Join-angebundenen
  *     Tabelle) kann zusätzlich ein einschränkender Filter durch den Zusatz `{filter=ausdruck}`
  *     angegeben werden, wobei `ausdruck` das Selektionskriertium in [CQL2

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SchemaSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SchemaSql.java
@@ -48,6 +48,11 @@ public interface SchemaSql extends SchemaBase<SchemaSql> {
 
   Optional<String> getConstantValue();
 
+  @Value.Default
+  default boolean isExpression() {
+    return false;
+  }
+
   @Value.Derived
   default boolean isConstant() {
     return getConstantValue().isPresent();
@@ -60,7 +65,15 @@ public interface SchemaSql extends SchemaBase<SchemaSql> {
     List<String> path =
         getRelation().isEmpty()
             ? getSubDecoder().isPresent()
-                ? List.of(String.format("[%s]%s", getSubDecoder().get(), getName()))
+                ? List.of(
+                    String.format(
+                            "[%s]%s",
+                            getSubDecoder().get(),
+                            isExpression()
+                                ? String.format(
+                                    "{sql=%s}", getSubDecoderPaths().values().iterator().next())
+                                : getName())
+                        + getFilterString().map(filter -> "{filter=" + filter + "}").orElse(""))
                 : ImmutableList.of(
                     getName()
                         + getFilterString().map(filter -> "{filter=" + filter + "}").orElse(""))

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
@@ -109,6 +109,10 @@ public interface SqlDialect {
     return ImmutableSet.of();
   }
 
+  default String applyToExpression(String table, String name, Map<String, String> subDecoderPaths) {
+    return name;
+  }
+
   Map<SpatialFunction, String> SPATIAL_OPERATORS =
       new ImmutableMap.Builder<SpatialFunction, String>()
           .put(SpatialFunction.S_EQUALS, "ST_Equals")

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.threeten.extra.Interval;
@@ -185,5 +186,15 @@ public class SqlDialectGpkg implements SqlDialect {
   @Override
   public String escapeString(String value) {
     return value.replaceAll("'", "''");
+  }
+
+  @Override
+  public String applyToExpression(String table, String name, Map<String, String> subDecoderPaths) {
+    if (!subDecoderPaths.isEmpty()) {
+      String expression =
+          subDecoderPaths.values().iterator().next().replaceAll("\\$(?:t|T|table)\\$", table);
+      return String.format("(%s) AS %s", expression, name);
+    }
+    return SqlDialect.super.applyToExpression(table, name, subDecoderPaths);
   }
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
@@ -289,4 +289,14 @@ public class SqlDialectPgis implements SqlDialect {
   public String escapeString(String value) {
     return value.replaceAll("'", "''");
   }
+
+  @Override
+  public String applyToExpression(String table, String name, Map<String, String> subDecoderPaths) {
+    if (!subDecoderPaths.isEmpty()) {
+      String expression =
+          subDecoderPaths.values().iterator().next().replaceAll("\\$(?:t|T|table)\\$", table);
+      return String.format("(%s) AS %s", expression, name);
+    }
+    return SqlDialect.super.applyToExpression(table, name, subDecoderPaths);
+  }
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlPath.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlPath.java
@@ -19,11 +19,20 @@ import org.immutables.value.Value;
 @Value.Immutable
 public interface SqlPath extends SourcePath {
 
+  enum JoinType {
+    INNER,
+    LEFT,
+    RIGHT,
+    FULL
+  }
+
   String getName();
 
   List<SqlPath> getParentTables();
 
   Optional<Tuple<String, String>> getJoin();
+
+  Optional<JoinType> getJoinType();
 
   Optional<String> getConnector();
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlRelation.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlRelation.java
@@ -9,6 +9,7 @@ package de.ii.xtraplatform.features.sql.domain;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import de.ii.xtraplatform.features.sql.domain.SqlPath.JoinType;
 import java.util.List;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -47,6 +48,11 @@ public interface SqlRelation {
   Optional<String> getJunctionTarget();
 
   Optional<String> getJunctionFilter();
+
+  @Value.Default
+  default JoinType getJoinType() {
+    return JoinType.INNER;
+  }
 
   @Value.Check
   default void check() {

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/QuerySchemaDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/QuerySchemaDeriverSpec.groovy
@@ -8,13 +8,18 @@
 package de.ii.xtraplatform.features.sql.app
 
 import de.ii.xtraplatform.cql.app.CqlImpl
+import de.ii.xtraplatform.features.domain.Decoder
+import de.ii.xtraplatform.features.domain.DecoderFactory
 import de.ii.xtraplatform.features.domain.FeatureSchemaFixtures
 import de.ii.xtraplatform.features.domain.MappingOperationResolver
+import de.ii.xtraplatform.features.json.app.DecoderFactoryJson
 import de.ii.xtraplatform.features.sql.domain.ImmutableSqlPathDefaults
 import de.ii.xtraplatform.features.sql.domain.SchemaSql
 import de.ii.xtraplatform.features.sql.domain.SqlPathParser
 import spock.lang.Shared
 import spock.lang.Specification
+
+import javax.ws.rs.core.MediaType
 
 class QuerySchemaDeriverSpec extends Specification {
 
@@ -26,7 +31,7 @@ class QuerySchemaDeriverSpec extends Specification {
     def setupSpec() {
         def defaults = new ImmutableSqlPathDefaults.Builder().build()
         def cql = new CqlImpl()
-        def pathParser = new SqlPathParser(defaults, cql, Set.of("JSON"))
+        def pathParser = new SqlPathParser(defaults, cql, Map.of("JSON", new DecoderFactoryJson()))
         schemaDeriver = new QuerySchemaDeriver(pathParser)
         mappingOperationResolver = new MappingOperationResolver()
     }
@@ -44,7 +49,7 @@ class QuerySchemaDeriverSpec extends Specification {
         where:
 
         casename                                     | source                                                    || expected
-        "value array"                                | FeatureSchemaFixtures.VALUE_ARRAY || QuerySchemaFixtures.VALUE_ARRAY
+        "value array"                                | FeatureSchemaFixtures.VALUE_ARRAY                         || QuerySchemaFixtures.VALUE_ARRAY
         "object array"                               | FeatureSchemaFixtures.OBJECT_ARRAY                        || QuerySchemaFixtures.OBJECT_ARRAY
         "merge"                                      | FeatureSchemaFixtures.MERGE                               || QuerySchemaFixtures.MERGE
         "self joins"                                 | FeatureSchemaFixtures.SELF_JOINS                          || QuerySchemaFixtures.SELF_JOINS

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlPathFixtures.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlPathFixtures.groovy
@@ -7,11 +7,12 @@
  */
 package de.ii.xtraplatform.features.sql.app
 
-import de.ii.xtraplatform.cql.domain.CqlFilter
+
 import de.ii.xtraplatform.cql.domain.Eq
 import de.ii.xtraplatform.cql.domain.ScalarLiteral
 import de.ii.xtraplatform.features.domain.ImmutableTuple
 import de.ii.xtraplatform.features.sql.domain.ImmutableSqlPath
+import de.ii.xtraplatform.features.sql.domain.SqlPath
 
 class SqlPathFixtures {
 
@@ -29,14 +30,17 @@ class SqlPathFixtures {
     static BRANCH_TABLE = baseTable()
             .name("explorationsite")
             .join(ImmutableTuple.of("id", "boreholepath_fk"))
+            .joinType(SqlPath.JoinType.INNER)
             .build()
 
     static BRANCH_TABLES = baseTable()
             .name("task")
             .join(ImmutableTuple.of("task_fk", "id"))
+            .joinType(SqlPath.JoinType.INNER)
             .parentTables([baseTable()
                                    .name("explorationsite_task")
                                    .join(ImmutableTuple.of("id", "explorationsite_fk"))
+                                   .joinType(SqlPath.JoinType.INNER)
                                    .build()])
             .build()
 
@@ -53,24 +57,28 @@ class SqlPathFixtures {
             .parentTables([baseTable()
                                    .name("externalprovider_externalprovidername")
                                    .join(ImmutableTuple.of("id", "externalprovider_fk"))
+                                   .joinType(SqlPath.JoinType.INNER)
                                    .build()])
             .build()
 
     static CUSTOM_SORT_KEY = baseTable()
             .name("externalprovider_externalprovidername")
             .join(ImmutableTuple.of("id", "externalprovider_fk"))
+            .joinType(SqlPath.JoinType.INNER)
             .sortKey("oid")
             .build()
 
     static CUSTOM_PRIMARY_KEY = baseTable()
             .name("externalprovider_externalprovidername")
             .join(ImmutableTuple.of("id", "externalprovider_fk"))
+            .joinType(SqlPath.JoinType.INNER)
             .primaryKey("oid")
             .build()
 
     static CUSTOM_FILTER = baseTable()
             .name("externalprovider_externalprovidername")
             .join(ImmutableTuple.of("id", "externalprovider_fk"))
+            .joinType(SqlPath.JoinType.INNER)
             .filter(Eq.of("category", ScalarLiteral.of(1)))
             .filterString("category=1")
             .build()
@@ -78,6 +86,7 @@ class SqlPathFixtures {
     static MULTIPLE_FLAGS = baseTable()
             .name("externalprovider_externalprovidername")
             .join(ImmutableTuple.of("id", "externalprovider_fk"))
+            .joinType(SqlPath.JoinType.INNER)
             .sortKey("oid")
             .primaryKey("oid")
             .filter(Eq.of("category", ScalarLiteral.of(1)))

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlPathParserSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlPathParserSpec.groovy
@@ -22,7 +22,7 @@ class SqlPathParserSpec extends Specification {
         def defaults = new ImmutableSqlPathDefaults.Builder().build()
         def cql = new CqlImpl()
 
-        pathParser = new SqlPathParser(defaults, cql, Set.of())
+        pathParser = new SqlPathParser(defaults, cql, Map.of())
     }
 
     def 'root table'() {

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -15,6 +15,7 @@ import de.ii.xtraplatform.features.domain.FeatureSchemaFixtures
 import de.ii.xtraplatform.features.domain.MappingOperationResolver
 import de.ii.xtraplatform.features.domain.SortKey
 import de.ii.xtraplatform.features.domain.Tuple
+import de.ii.xtraplatform.features.json.app.DecoderFactoryJson
 import de.ii.xtraplatform.features.sql.domain.ImmutableSqlPathDefaults
 import de.ii.xtraplatform.features.sql.domain.SchemaSql
 import de.ii.xtraplatform.features.sql.domain.SqlDialectPgis
@@ -39,7 +40,7 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
     def setupSpec() {
         def defaults = new ImmutableSqlPathDefaults.Builder().build()
         def cql = new CqlImpl()
-        def pathParser = new SqlPathParser(defaults, cql, Set.of("JSON"))
+        def pathParser = new SqlPathParser(defaults, cql, Map.of("JSON", new DecoderFactoryJson()))
         schemaDeriver = new QuerySchemaDeriver(pathParser)
         mappingOperationResolver = new MappingOperationResolver()
     }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/app/DecoderFactoriesImpl.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/app/DecoderFactoriesImpl.java
@@ -8,6 +8,7 @@
 package de.ii.xtraplatform.features.app;
 
 import com.github.azahnen.dagger.annotations.AutoBind;
+import com.google.common.collect.ImmutableMap;
 import dagger.Lazy;
 import de.ii.xtraplatform.features.domain.Decoder;
 import de.ii.xtraplatform.features.domain.DecoderFactories;
@@ -15,6 +16,7 @@ import de.ii.xtraplatform.features.domain.DecoderFactory;
 import de.ii.xtraplatform.features.domain.DecoderFactory.FeatureDecoderFactory;
 import de.ii.xtraplatform.features.domain.DecoderFactory.GeometryDecoderFactory;
 import de.ii.xtraplatform.features.domain.FeatureDecoder;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
@@ -61,5 +63,13 @@ public class DecoderFactoriesImpl implements DecoderFactories {
         .filter(factory -> factory.getGeometryMediaType().equals(mediaType))
         .map(GeometryDecoderFactory::createGeometryDecoder)
         .findFirst();
+  }
+
+  @Override
+  public Map<String, DecoderFactory> getConnectorDecoders() {
+    return factories.get().stream()
+        .filter(factory -> factory.getConnectorString().isPresent())
+        .map(factory -> Map.entry(factory.getConnectorString().get(), factory))
+        .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/DecoderFactories.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/DecoderFactories.java
@@ -7,6 +7,7 @@
  */
 package de.ii.xtraplatform.features.domain;
 
+import java.util.Map;
 import java.util.Optional;
 import javax.ws.rs.core.MediaType;
 
@@ -17,4 +18,6 @@ public interface DecoderFactories {
   Optional<FeatureDecoder<byte[]>> createFeatureDecoder(MediaType mediaType);
 
   Optional<Decoder> createGeometryDecoder(MediaType mediaType);
+
+  Map<String, DecoderFactory> getConnectorDecoders();
 }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/DecoderFactory.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/DecoderFactory.java
@@ -8,6 +8,8 @@
 package de.ii.xtraplatform.features.domain;
 
 import com.github.azahnen.dagger.annotations.AutoMultiBind;
+import de.ii.xtraplatform.base.domain.util.Tuple;
+import java.util.Optional;
 import javax.ws.rs.core.MediaType;
 
 // TODO: only for byte decoders?
@@ -34,4 +36,13 @@ public interface DecoderFactory {
   MediaType getMediaType();
 
   Decoder createDecoder();
+
+  default Optional<String> getConnectorString() {
+    return Optional.empty();
+  }
+
+  default de.ii.xtraplatform.base.domain.util.Tuple<String, String> parseSourcePath(
+      String path, String column, String flags, String connectorSpec) {
+    return Tuple.of(column, "");
+  }
 }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaMapping.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/SchemaMapping.java
@@ -109,7 +109,7 @@ public interface SchemaMapping extends SchemaMappingBase<FeatureSchema> {
   default String cleanPath(String path) {
     if (path.contains("{")) {
       int i = path.indexOf("{");
-      if (path.startsWith("filter", i + 1)) {
+      if (path.startsWith("filter", i + 1) || path.startsWith("sql", i + 1)) {
         return path.substring(0, i + 2) + cleanPath(path.substring(i + 2));
       }
       return path.substring(0, path.indexOf("{"));

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlyQueryables.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlyQueryables.java
@@ -77,6 +77,9 @@ public class OnlyQueryables implements SchemaVisitorTopDown<FeatureSchema, Featu
         if ((!wildcard && !included.contains(path)) || excluded.contains(path)) {
           return null;
         }
+        if (excludePathMatcher.test(schema.getSourcePath().orElse(""))) {
+          return null;
+        }
       } else if (!schema.isObject()
           || (!parents.isEmpty() && visitedProperties.stream().noneMatch(Objects::nonNull))) {
         return null;

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlySortables.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/OnlySortables.java
@@ -74,6 +74,9 @@ public class OnlySortables implements SchemaVisitorTopDown<FeatureSchema, Featur
         if ((!wildcard && !included.contains(path)) || excluded.contains(path)) {
           return null;
         }
+        if (excludePathMatcher.test(schema.getSourcePath().orElse(""))) {
+          return null;
+        }
       } else if (!schema.isFeature()) {
         return null;
       }


### PR DESCRIPTION
Adds support for custom SQL expressions and other join types than `INNER`.

**Examples**

```yml
areaValue:
  sourcePath: "[EXPRESSION]{sql=$T$.afl+55.5}"
  type: FLOAT
```

```yml
geometrie:
   sourcePath: "[sch=schl]katasterbezirk{joinType=LEFT}/geometrie"
```

**Todo**
- [x] issue
- [x] docs
- [x] disable queryable and sortable for expression properties

