### PR TITLE
fix: geometry missing from generated provider config due to key collision and case mismatch

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -187,13 +187,11 @@ public class SchemaGeneratorSql implements SchemaGenerator {
               featureProperty.excludedScopes(ImmutableList.of(Scope.RECEIVABLE));
             }
             if (featurePropertyType == SchemaBase.Type.GEOMETRY) {
-              String geometryInfoKey =
-                  String.format("%s.%s", schema.getName(), table.getName())
-                      .toLowerCase(Locale.ROOT);
-              if (!geometryInfos.containsKey(geometryInfoKey)) {
+              GeoInfo geometryInfo =
+                  lookupGeometryInfo(geometryInfos, schema.getName(), table.getName());
+              if (Objects.isNull(geometryInfo)) {
                 continue;
               }
-              GeoInfo geometryInfo = geometryInfos.get(geometryInfoKey);
 
               // if srid=0, do not set, will use default
               try {
@@ -262,16 +260,9 @@ public class SchemaGeneratorSql implements SchemaGenerator {
           }
         }
         if (featurePropertyType == SchemaBase.Type.GEOMETRY) {
-          String geometryInfoKeySchema =
-              String.format("%s.%s", table.getSchema().getName(), table.getName())
-                  .toLowerCase(Locale.ROOT);
-          String geometryInfoKeyTable = table.getName().toLowerCase(Locale.ROOT);
-          GeoInfo geometryInfo = null;
-          if (geometryInfos.containsKey(geometryInfoKeySchema)) {
-            geometryInfo = geometryInfos.get(geometryInfoKeySchema);
-          } else if (geometryInfos.containsKey(geometryInfoKeyTable)) {
-            geometryInfo = geometryInfos.get(geometryInfoKeyTable);
-          } else {
+          GeoInfo geometryInfo =
+              lookupGeometryInfo(geometryInfos, table.getSchema().getName(), table.getName());
+          if (Objects.isNull(geometryInfo)) {
             continue;
           }
 
@@ -302,6 +293,23 @@ public class SchemaGeneratorSql implements SchemaGenerator {
     }
 
     return featureSchema;
+  }
+
+  private GeoInfo lookupGeometryInfo(
+      Map<String, GeoInfo> geometryInfos, String schema, String table) {
+    String geometryInfoKeySchema =
+        String.format("%s.%s", Objects.requireNonNullElse(schema, ""), table)
+            .toLowerCase(Locale.ROOT);
+    String geometryInfoKeyTable = table.toLowerCase(Locale.ROOT);
+
+    if (geometryInfos.containsKey(geometryInfoKeySchema)) {
+      return geometryInfos.get(geometryInfoKeySchema);
+    }
+    if (geometryInfos.containsKey(geometryInfoKeyTable)) {
+      return geometryInfos.get(geometryInfoKeyTable);
+    }
+
+    return null;
   }
 
   private SchemaBase.Type getFeaturePropertyType(ColumnDataType columnDataType) {

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -186,10 +187,13 @@ public class SchemaGeneratorSql implements SchemaGenerator {
               featureProperty.excludedScopes(ImmutableList.of(Scope.RECEIVABLE));
             }
             if (featurePropertyType == SchemaBase.Type.GEOMETRY) {
-              if (!geometryInfos.containsKey(table.getName())) {
+              String geometryInfoKey =
+                  String.format("%s.%s", schema.getName(), table.getName())
+                      .toLowerCase(Locale.ROOT);
+              if (!geometryInfos.containsKey(geometryInfoKey)) {
                 continue;
               }
-              GeoInfo geometryInfo = geometryInfos.get(table.getName());
+              GeoInfo geometryInfo = geometryInfos.get(geometryInfoKey);
 
               // if srid=0, do not set, will use default
               try {
@@ -258,10 +262,13 @@ public class SchemaGeneratorSql implements SchemaGenerator {
           }
         }
         if (featurePropertyType == SchemaBase.Type.GEOMETRY) {
-          if (!geometryInfos.containsKey(table.getName())) {
+          String geometryInfoKey =
+              String.format("%s.%s", table.getSchema().getName(), table.getName())
+                  .toLowerCase(Locale.ROOT);
+          if (!geometryInfos.containsKey(geometryInfoKey)) {
             continue;
           }
-          GeoInfo geometryInfo = geometryInfos.get(table.getName());
+          GeoInfo geometryInfo = geometryInfos.get(geometryInfoKey);
 
           // if srid=0, do not set, will use default
           try {
@@ -295,8 +302,9 @@ public class SchemaGeneratorSql implements SchemaGenerator {
   private SchemaBase.Type getFeaturePropertyType(ColumnDataType columnDataType) {
     // TODO: pass GeoInfo to determine geo columns
     try {
-      if ("GEOMETRY".equals(columnDataType.getName())
-          || WktWkbGeometryType.valueOf(columnDataType.getName()) != WktWkbGeometryType.NONE) {
+      if ("GEOMETRY".equalsIgnoreCase(columnDataType.getName())
+          || WktWkbGeometryType.valueOf(columnDataType.getName().toUpperCase(Locale.ROOT))
+              != WktWkbGeometryType.NONE) {
         return SchemaBase.Type.GEOMETRY;
       }
     } catch (Exception ignore) {

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -262,13 +262,18 @@ public class SchemaGeneratorSql implements SchemaGenerator {
           }
         }
         if (featurePropertyType == SchemaBase.Type.GEOMETRY) {
-          String geometryInfoKey =
+          String geometryInfoKeySchema =
               String.format("%s.%s", table.getSchema().getName(), table.getName())
                   .toLowerCase(Locale.ROOT);
-          if (!geometryInfos.containsKey(geometryInfoKey)) {
+          String geometryInfoKeyTable = table.getName().toLowerCase(Locale.ROOT);
+          GeoInfo geometryInfo = null;
+          if (geometryInfos.containsKey(geometryInfoKeySchema)) {
+            geometryInfo = geometryInfos.get(geometryInfoKeySchema);
+          } else if (geometryInfos.containsKey(geometryInfoKeyTable)) {
+            geometryInfo = geometryInfos.get(geometryInfoKeyTable);
+          } else {
             continue;
           }
-          GeoInfo geometryInfo = geometryInfos.get(geometryInfoKey);
 
           // if srid=0, do not set, will use default
           try {

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SqlDbmsAdapterGpkg.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SqlDbmsAdapterGpkg.java
@@ -31,6 +31,7 @@ import java.sql.Statement;
 import java.text.Collator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -185,16 +186,23 @@ public class SqlDbmsAdapterGpkg implements SqlDbmsAdapter {
     Map<String, GeoInfo> result = new LinkedHashMap<>();
 
     while (rs.next()) {
-      result.put(
-          rs.getString(GeoInfo.TABLE),
+      String table = rs.getString(GeoInfo.TABLE);
+      String tableKey = table.toLowerCase(Locale.ROOT);
+      String schemaTableKey = String.format("%s.%s", "main", table).toLowerCase(Locale.ROOT);
+      GeoInfo geoInfo =
           ImmutableGeoInfo.of(
               null,
-              rs.getString(GeoInfo.TABLE),
+              table,
               rs.getString(GeoInfo.COLUMN),
               rs.getString(GeoInfo.DIMENSION),
               rs.getString(GeoInfo.SRID),
               forceAxisOrder((DbInfoGpkg) dbInfo).name(),
-              rs.getString(GeoInfo.TYPE)));
+              rs.getString(GeoInfo.TYPE));
+
+      // keep a normalized table-only key as canonical lookup key
+      result.put(tableKey, geoInfo);
+      // additionally provide normalized schema.table compatibility key
+      result.put(schemaTableKey, geoInfo);
     }
 
     return result;

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SqlDbmsAdapterPgis.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SqlDbmsAdapterPgis.java
@@ -184,11 +184,15 @@ public class SqlDbmsAdapterPgis implements SqlDbmsAdapter {
     Map<String, GeoInfo> result = new LinkedHashMap<>();
 
     while (rs.next()) {
+      String schema = rs.getString(GeoInfo.SCHEMA);
+      String table = rs.getString(GeoInfo.TABLE);
+      String key = String.format("%s.%s", schema, table).toLowerCase(Locale.ROOT);
+
       result.put(
-          rs.getString(GeoInfo.TABLE),
+          key,
           ImmutableGeoInfo.of(
-              rs.getString(GeoInfo.SCHEMA),
-              rs.getString(GeoInfo.TABLE),
+              schema,
+              table,
               rs.getString(GeoInfo.COLUMN),
               rs.getString(GeoInfo.DIMENSION),
               rs.getString(GeoInfo.SRID),


### PR DESCRIPTION
Closes ldproxy/editor#27

Three related bugs caused geometry to be silently dropped from generated provider/collection configs:

Key collision in SqlDbmsAdapterPgis.getGeoInfo: The geometryInfos map was keyed only by table name. When the same table name existed in multiple schemas (e.g. ALKIS, AFIS, ATKISBDLM), later entries overwrote earlier ones. Fixed by changing the key to schema.table (lowercased via Locale.ROOT).

Case-sensitive geometry type detection in SchemaGeneratorSql.getFeaturePropertyType: PostgreSQL/SchemaCrawler reports the column data type as geometry (lowercase), but the check was "GEOMETRY".equals(...) — an exact case-sensitive match that always evaluated to false. This caused the geometry column to be silently discarded as UNKNOWN type. Fixed by using equalsIgnoreCase and normalizing to uppercase before WktWkbGeometryType.valueOf(...).

Lookup key case mismatch: The map stores keys like alkis.o02310 (lowercase) but SchemaGeneratorSql was looking up ALKIS.o02310 (SchemaCrawler returns the schema name in original case), so lookups always missed. Fixed by applying .toLowerCase(Locale.ROOT) at both lookup sites.