### PR TITLE
Editor: Fix NPE when generating schema from PostgreSQL views

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -121,16 +121,6 @@ public class SchemaGeneratorSql implements SchemaGenerator {
                                   if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debug("Stacktrace:", e);
                                   }
-                                  System.out.println(
-                                      "SCHEMA_ERROR "
-                                          + schema.getKey()
-                                          + "."
-                                          + tableName
-                                          + ": "
-                                          + e.getClass().getSimpleName()
-                                          + " | "
-                                          + Objects.requireNonNullElse(
-                                              e.getMessage(), "no message"));
                                   return null;
                                 }
                               }))

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -121,6 +121,16 @@ public class SchemaGeneratorSql implements SchemaGenerator {
                                   if (LOGGER.isDebugEnabled()) {
                                     LOGGER.debug("Stacktrace:", e);
                                   }
+                                  System.out.println(
+                                      "SCHEMA_ERROR "
+                                          + schema.getKey()
+                                          + "."
+                                          + tableName
+                                          + ": "
+                                          + e.getClass().getSimpleName()
+                                          + " | "
+                                          + Objects.requireNonNullElse(
+                                              e.getMessage(), "no message"));
                                   return null;
                                 }
                               }))

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java
@@ -112,9 +112,19 @@ public class SchemaGeneratorSql implements SchemaGenerator {
 
                                   return getFeatureType(table, geoInfo);
                                 } catch (Throwable e) {
+                                  LOGGER.warn(
+                                      "Could not generate schema for {}.{}: {} ({})",
+                                      schema.getKey(),
+                                      tableName,
+                                      e.getClass().getSimpleName(),
+                                      Objects.requireNonNullElse(e.getMessage(), "no message"));
+                                  if (LOGGER.isDebugEnabled()) {
+                                    LOGGER.debug("Stacktrace:", e);
+                                  }
                                   return null;
                                 }
                               }))
+              .filter(Objects::nonNull)
               .collect(Collectors.toList());
 
       LOGGER.debug("Finished crawling SQL schema");

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
@@ -23,6 +23,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.create.view.CreateView;
 import net.sf.jsqlparser.statement.select.FromItemVisitorAdapter;
 import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -149,10 +150,14 @@ public class ViewInfo {
     net.sf.jsqlparser.statement.Statement parsed =
         CCJSqlParserUtil.parse(select, ccjSqlParser -> ccjSqlParser.setErrorRecovery(true));
 
-    if (!(parsed instanceof Select)) {
+    Select statement;
+    if (parsed instanceof Select) {
+      statement = (Select) parsed;
+    } else if (parsed instanceof CreateView) {
+      statement = ((CreateView) parsed).getSelect();
+    } else {
       throw new JSQLParserException("View definition is not a SELECT statement");
     }
-    Select statement = (Select) parsed;
 
     PlainSelect selectBody = (PlainSelect) statement.getSelectBody();
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
@@ -68,6 +68,9 @@ public class ViewInfo {
 
   public static Optional<Tuple<String, String>> getOriginalTableAndColumn(
       String viewDefinition, String columnName) {
+    if (Objects.isNull(viewDefinition)) {
+      return Optional.empty();
+    }
     try {
       PlainSelect select = parse(viewDefinition);
 
@@ -143,9 +146,13 @@ public class ViewInfo {
   }
 
   private static PlainSelect parse(String select) throws JSQLParserException, ParseException {
-    Select statement =
-        (Select)
-            CCJSqlParserUtil.parse(select, ccjSqlParser -> ccjSqlParser.setErrorRecovery(true));
+    net.sf.jsqlparser.statement.Statement parsed =
+        CCJSqlParserUtil.parse(select, ccjSqlParser -> ccjSqlParser.setErrorRecovery(true));
+
+    if (!(parsed instanceof Select)) {
+      throw new JSQLParserException("View definition is not a SELECT statement");
+    }
+    Select statement = (Select) parsed;
 
     PlainSelect selectBody = (PlainSelect) statement.getSelectBody();
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java
@@ -34,6 +34,9 @@ import net.sf.jsqlparser.util.TablesNamesFinder;
 public class ViewInfo {
 
   public static List<String> getOriginalTables(String viewDefinition) {
+    if (Objects.isNull(viewDefinition)) {
+      return ImmutableList.of();
+    }
     try {
       PlainSelect select = parse(viewDefinition);
 


### PR DESCRIPTION
Closes ldproxy/editor#29

- SchemaCrawler returns view definitions wrapped as `CREATE OR REPLACE VIEW … AS …`, which JSQLParser parses as [CreateView](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#26%2C48), not [Select](jdt://contents/java.xml/com.sun.org.apache.bcel.internal.generic/Select.java?%3Djdt.ls-java-project%2F%5C%2FLibrary%5C%2FJava%5C%2FJavaVirtualMachines%5C%2Fgraalvm-21.jdk%5C%2FContents%5C%2FHome%5C%2Flib%5C%2Fjrt-fs.jar%60java.xml%3D%2Fjavadoc_location%3D%2Fhttps%3A%5C%2F%5C%2Fdocs.oracle.com%5C%2Fen%5C%2Fjava%5C%2Fjavase%5C%2F21%5C%2Fdocs%5C%2Fapi%5C%2F%3D%2F%3Ccom.sun.org.apache.bcel.internal.generic%28Select.class#38%2C23). The old code's blind cast to [Select](jdt://contents/java.xml/com.sun.org.apache.bcel.internal.generic/Select.java?%3Djdt.ls-java-project%2F%5C%2FLibrary%5C%2FJava%5C%2FJavaVirtualMachines%5C%2Fgraalvm-21.jdk%5C%2FContents%5C%2FHome%5C%2Flib%5C%2Fjrt-fs.jar%60java.xml%3D%2Fjavadoc_location%3D%2Fhttps%3A%5C%2F%5C%2Fdocs.oracle.com%5C%2Fen%5C%2Fjava%5C%2Fjavase%5C%2F21%5C%2Fdocs%5C%2Fapi%5C%2F%3D%2F%3Ccom.sun.org.apache.bcel.internal.generic%28Select.class#38%2C23) triggered a `ClassCastException` that [setErrorRecovery(true)](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#151%2C69) silently turned into a `null` result.
- The following [getSelectBody()](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#162%2C54) call on `null` threw an NPE that wasn't caught locally and ultimately killed schema generation for the affected view, leaving [types: {}](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java#81%2C33) in the generated YAML.
- [ViewInfo.parse()](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#35%2C14) now handles both [Select](jdt://contents/java.xml/com.sun.org.apache.bcel.internal.generic/Select.java?%3Djdt.ls-java-project%2F%5C%2FLibrary%5C%2FJava%5C%2FJavaVirtualMachines%5C%2Fgraalvm-21.jdk%5C%2FContents%5C%2FHome%5C%2Flib%5C%2Fjrt-fs.jar%60java.xml%3D%2Fjavadoc_location%3D%2Fhttps%3A%5C%2F%5C%2Fdocs.oracle.com%5C%2Fen%5C%2Fjava%5C%2Fjavase%5C%2F21%5C%2Fdocs%5C%2Fapi%5C%2F%3D%2F%3Ccom.sun.org.apache.bcel.internal.generic%28Select.class#38%2C23) and [CreateView](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#26%2C48) (unwrapping the latter), and rejects anything else via a regular [JSQLParserException](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/ViewInfo.java#16%2C26) that existing `catch` blocks handle gracefully.
- [SchemaGeneratorSql](file:///Users/pascal/Documents/GitHub/xtraplatform-spatial/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/SchemaGeneratorSql.java#40%2C14) now logs a `WARN` for failed per-table generation and filters out `null` results, so a single problematic table can no longer break the whole run.
