### PR TITLE
features-sql: avoid redundant meta queries for large result limits

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureQueryEncoderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureQueryEncoderSql.java
@@ -53,7 +53,6 @@ public class FeatureQueryEncoderSql implements FeatureQueryEncoder<SqlQueryBatch
   private final Map<String, List<SqlQueryTemplates>> allQueryTemplates;
   private final Map<String, List<SqlQueryTemplates>> allQueryTemplatesMutations;
   private final int chunkSize;
-  private final boolean skipRedundantMetaQueries;
   private final SqlDialect sqlDialect;
   private final boolean geometryAsWkb;
 
@@ -65,7 +64,6 @@ public class FeatureQueryEncoderSql implements FeatureQueryEncoder<SqlQueryBatch
     this.allQueryTemplates = allQueryTemplates;
     this.allQueryTemplatesMutations = allQueryTemplatesMutations;
     this.chunkSize = queryGeneratorSettings.getChunkSize();
-    this.skipRedundantMetaQueries = !queryGeneratorSettings.getComputeNumberMatched();
     this.geometryAsWkb = queryGeneratorSettings.getGeometryAsWkb();
     this.sqlDialect = sqlDialect;
   }
@@ -126,7 +124,6 @@ public class FeatureQueryEncoderSql implements FeatureQueryEncoder<SqlQueryBatch
         .offset(query.getOffset())
         .chunkSize(chunkSize)
         .isSingleFeature(query.returnsSingleFeature())
-        .isAllowSkipMetaQueries(skipRedundantMetaQueries)
         .build()
         .withQuerySets(querySets);
   }
@@ -200,7 +197,10 @@ public class FeatureQueryEncoderSql implements FeatureQueryEncoder<SqlQueryBatch
                             additionalQueryParameters,
                             query.getOffset() > 0,
                             maxLimit > 0 && !query.hitsOnly(),
-                            query.hitsOnly()));
+                            query.hitsOnly(),
+                            // numberMatched is invariant across chunks, so compute it only on the
+                            // first chunk of each collection; later chunks reuse that value
+                            chunk == 0));
 
     TriFunction<SqlRowMeta, Long, Long, Stream<String>> valueQueries =
         (metaResult, maxLimit, skipped) ->

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplates.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplates.java
@@ -36,7 +36,8 @@ public interface SqlQueryTemplates {
         Map<String, String> virtualTables,
         boolean withNumberSkipped,
         boolean withNumberReturned,
-        boolean forceNumberMatched);
+        boolean forceNumberMatched,
+        boolean withNumberMatched);
   }
 
   @FunctionalInterface

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriver.java
@@ -96,7 +96,8 @@ public class SqlQueryTemplatesDeriver {
         virtualTables,
         withNumberSkipped,
         withNumberReturned,
-        forceNumberMatched) -> {
+        forceNumberMatched,
+        withNumberMatched) -> {
       String limitAndOffsetSql = sqlDialect.applyToLimitAndOffset(limit, offset);
       String skipOffsetSql = skipOffset > 0 ? sqlDialect.applyToOffset(skipOffset) : "";
       String asIds = sqlDialect.applyToAsIds();
@@ -130,7 +131,7 @@ public class SqlQueryTemplatesDeriver {
                       sqlDialect.castToBigInt(0)));
 
       String numberMatched =
-          computeNumberMatched || forceNumberMatched
+          (computeNumberMatched || forceNumberMatched) && withNumberMatched
               ? String.format(
                   "SELECT count(*) AS numberMatched FROM (SELECT A.%2$s AS %4$s FROM %1$s A%3$s ORDER BY 1)%5$s",
                   tableName, schema.getSortKey(), where, SKEY, asIds)

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlConnector.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlConnector.java
@@ -51,7 +51,6 @@ public interface SqlConnector
     private final long limit;
     private final long offset;
     private final long chunkSize;
-    private final boolean allowSkipMetaQueries;
     private long featureCountdown;
     private long numberSkipped;
     private String lastTable;
@@ -59,11 +58,10 @@ public interface SqlConnector
     private long lastNumberSkipped;
     private boolean noOffset;
 
-    public Paging(long limit, long offset, long chunkSize, boolean allowSkipMetaQueries) {
+    public Paging(long limit, long offset, long chunkSize) {
       this.limit = limit;
       this.offset = offset;
       this.chunkSize = chunkSize;
-      this.allowSkipMetaQueries = allowSkipMetaQueries;
 
       this.featureCountdown = limit;
       this.numberSkipped = 0L;
@@ -76,8 +74,11 @@ public interface SqlConnector
     Optional<Tuple<Long, Long>> get(String currentTable) {
       long found = lastNumberReturned + lastNumberSkipped;
 
+      // Once the limit is reached or the current collection is exhausted (its last chunk returned
+      // fewer rows than the chunk size), no further meta query is needed: there are no more rows to
+      // read and numberMatched was already computed on the collection's first chunk.
       if (featureCountdown <= 0 || (Objects.equals(lastTable, currentTable) && found < chunkSize)) {
-        return allowSkipMetaQueries ? Optional.empty() : Optional.of(Tuple.of(0L, offset));
+        return Optional.empty();
       }
 
       long ns = numberSkipped;
@@ -108,11 +109,7 @@ public interface SqlConnector
   default Reactive.Source<SqlRow> getSourceStream(
       SqlQueryBatch queryBatch, SqlQueryOptions options) {
     Paging paging =
-        new Paging(
-            queryBatch.getLimit(),
-            queryBatch.getOffset(),
-            queryBatch.getChunkSize(),
-            queryBatch.isAllowSkipMetaQueries());
+        new Paging(queryBatch.getLimit(), queryBatch.getOffset(), queryBatch.getChunkSize());
 
     Source<SqlRow> sqlRowSource1 =
         Source.iterable(queryBatch.getQuerySets())
@@ -245,8 +242,7 @@ public interface SqlConnector
                           new Paging(
                               queryBatch.getLimit(),
                               queryBatch.getOffset(),
-                              queryBatch.getChunkSize(),
-                              queryBatch.isAllowSkipMetaQueries());
+                              queryBatch.getChunkSize());
                       int[] i = {0};
 
                       if (options.isHitsOnly()) {

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlQueryBatch.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlQueryBatch.java
@@ -24,10 +24,5 @@ public interface SqlQueryBatch {
     return false;
   }
 
-  @Value.Default
-  default boolean isAllowSkipMetaQueries() {
-    return false;
-  }
-
   List<SqlQuerySet> getQuerySets();
 }

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -124,7 +124,7 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
 
 
     static String meta(List<SqlQueryTemplates> templates, List<SortKey> sortBy, Optional<Cql2Expression> userFilter) {
-        return templates.stream().map(t -> t.getMetaQueryTemplate().generateMetaQuery(10, 10, 0, sortBy, userFilter, ImmutableMap.of(), false, true, false)).collect(Collectors.joining("\n"))
+        return templates.stream().map(t -> t.getMetaQueryTemplate().generateMetaQuery(10, 10, 0, sortBy, userFilter, ImmutableMap.of(), false, true, false, true)).collect(Collectors.joining("\n"))
     }
 
     static List<String> values(List<SqlQueryTemplates> templates, int limit, int offset, List<SortKey> sortBy, Cql2Expression filter) {


### PR DESCRIPTION
A query with a large limit is split into limit/chunkSize query sets, each carrying its own meta query. Previously every chunk re-ran the full numberMatched count and, with computeNumberMatched enabled, meta queries kept being issued even after the result was exhausted - producing hundreds of identical counts for a single page.

numberMatched is now computed only on the first chunk of each collection (it is invariant across chunks); later chunks reuse that value. Meta queries also stop once the limit is reached or a collection is exhausted, independent of computeNumberMatched.

MetaQueryTemplate gains a withNumberMatched flag; the now-obsolete allowSkipMetaQueries flag is removed.

Closes https://github.com/ldproxy/ldproxy/issues/1643