### PR TITLE
features: add option to declare globally unique feature ids

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/AbstractFeatureProvider.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/AbstractFeatureProvider.java
@@ -332,6 +332,11 @@ public abstract class AbstractFeatureProvider<
     return Set.copyOf(types);
   }
 
+  @Override
+  public boolean featureIdsAreGloballyUnique() {
+    return getData().getGloballyUniqueFeatureIds();
+  }
+
   private boolean softClosePrevious(
       Runner previousRunner, FeatureProviderConnector<T, U, V> previousConnector) {
     if (Objects.nonNull(previousConnector) || Objects.nonNull(previousRunner)) {

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureInfo.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureInfo.java
@@ -29,4 +29,13 @@ public interface FeatureInfo {
   default boolean hasGeneratedId(String featureType) {
     return true;
   }
+
+  /**
+   * Whether feature ids are unique across all feature types of the provider, not just within a
+   * single type. Consumers that merge features from multiple types into one response can rely on
+   * this to keep ids unqualified.
+   */
+  default boolean featureIdsAreGloballyUnique() {
+    return false;
+  }
 }

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderDataV2.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureProviderDataV2.java
@@ -136,6 +136,24 @@ public interface FeatureProviderDataV2 extends ProviderData, AutoEntity, Extenda
   List<GeometryType> getProvidesGeometryTypes();
 
   /**
+   * @langEn If `true`, feature ids are unique across all feature types of the provider, not just
+   *     within a single type. Consumers that combine features from multiple types into one response
+   *     (for example the *Search* building block) can then keep the ids unchanged instead of
+   *     qualifying them with the collection to avoid collisions.
+   * @langDe Bei `true` sind Feature-Ids über alle Objektarten des Providers hinweg eindeutig, nicht
+   *     nur innerhalb einer Objektart. Komponenten, die Features aus mehreren Objektarten in einer
+   *     Antwort zusammenführen (zum Beispiel der Baustein *Search*), können die Ids dann
+   *     unverändert lassen, anstatt sie zur Vermeidung von Kollisionen mit der Collection zu
+   *     qualifizieren.
+   * @default false
+   * @since v4.8
+   */
+  @Value.Default
+  default boolean getGloballyUniqueFeatureIds() {
+    return false;
+  }
+
+  /**
    * @langEn Optional custom CQL2 functions that can be used in filters. See [Custom CQL2
    *     Functions](#custom-cql2-functions) for details and examples.
    * @langDe Optionale benutzerdefinierte CQL2-Funktionen, die in Filtern genutzt werden können.


### PR DESCRIPTION
New provider option `globallyUniqueFeatureIds` (default false), documented for the generated configuration docs. It is exposed through `FeatureInfo.featureIdsAreGloballyUnique()` and implemented in `AbstractFeatureProvider` from the provider data.

This lets consumers that merge features from several feature types into one response keep feature ids unchanged instead of qualifying them with the collection to avoid collisions.

Closes https://github.com/ldproxy/ldproxy/issues/1642