### PR TITLE
features: execute native statements on a mutation session for transaction hooks

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlMutationSession.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlMutationSession.java
@@ -1519,6 +1519,11 @@ public class SqlMutationSession implements FeatureTransactions.Session {
   }
 
   @Override
+  public List<String> execute(List<String> statements) {
+    return sqlSession.execute(statements);
+  }
+
+  @Override
   public void commit() {
     sqlSession.commit();
   }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlSession.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlSession.java
@@ -45,6 +45,17 @@ public interface SqlSession extends AutoCloseable {
    */
   List<String> runReturning(String sql);
 
+  /**
+   * Executes raw statements in order on this session's connection, ignoring any result sets, and
+   * returns the non-fatal SQL warnings they produced (e.g. PostgreSQL {@code RAISE WARNING} /
+   * {@code RAISE NOTICE}). A statement that fails throws and leaves the transaction open for
+   * rollback. Intended for transaction-lifecycle hooks (session setup, pre-commit checks).
+   *
+   * @param statements the statements to execute, in order
+   * @return the collected warning messages across all statements, in execution order
+   */
+  List<String> execute(List<String> statements);
+
   /** Commits all mutations performed against this session. */
   void commit();
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/JdbcSqlSession.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/infra/db/JdbcSqlSession.java
@@ -8,10 +8,12 @@
 package de.ii.xtraplatform.features.sql.infra.db;
 
 import de.ii.xtraplatform.base.domain.LogContext.MARKER;
+import de.ii.xtraplatform.features.domain.FeatureMutationHookException;
 import de.ii.xtraplatform.features.sql.domain.SqlSession;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLWarning;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
@@ -156,6 +158,31 @@ class JdbcSqlSession implements SqlSession {
       throw new IllegalStateException(
           "Mutation statement failed: " + e.getMessage() + " — statement: " + sql, e);
     }
+  }
+
+  @Override
+  public List<String> execute(List<String> statements) {
+    if (finalised) {
+      throw new IllegalStateException("SQL session is closed");
+    }
+    List<String> warnings = new ArrayList<>();
+    for (String sql : statements) {
+      if (LOGGER.isDebugEnabled(MARKER.SQL)) {
+        LOGGER.debug(MARKER.SQL, "Executing hook statement: {}", sql);
+      }
+      try (Statement statement = connection.createStatement()) {
+        statement.execute(sql);
+        for (SQLWarning w = statement.getWarnings(); w != null; w = w.getNextWarning()) {
+          warnings.add(w.getMessage());
+        }
+      } catch (SQLException e) {
+        // Expected, configuration-driven failure (e.g. a check function RAISE EXCEPTION) — carry
+        // the warnings collected so far so they survive the failure path.
+        throw new FeatureMutationHookException(
+            "Hook statement failed: " + e.getMessage() + " — statement: " + sql, e, warnings);
+      }
+    }
+    return warnings;
   }
 
   // Generators emit "RETURNING null" for child / junction / FK-update statements — these have

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureMutationHookException.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureMutationHookException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain;
+
+import java.util.List;
+
+/**
+ * Thrown by {@link FeatureTransactions.Session#execute(List)} when one of the raw statements (a
+ * transaction-lifecycle hook) fails. This is an expected, configuration-driven outcome — it
+ * triggers a rollback and is reported to the client — not an illegal state, so callers should log
+ * it quietly. Any non-fatal warnings collected from statements that ran before the failing one are
+ * carried in {@link #getWarnings()} so they are not lost on the failure path.
+ */
+public class FeatureMutationHookException extends RuntimeException {
+
+  private final List<String> warnings;
+
+  public FeatureMutationHookException(String message, Throwable cause, List<String> warnings) {
+    super(message, cause);
+    this.warnings = List.copyOf(warnings);
+  }
+
+  /** Warnings emitted by hook statements that ran successfully before the failing statement. */
+  public List<String> getWarnings() {
+    return warnings;
+  }
+}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTransactions.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureTransactions.java
@@ -283,6 +283,26 @@ public interface FeatureTransactions {
           "Clone-and-patch is not supported by this feature provider session");
     }
 
+    /**
+     * Executes raw native statements in order against this session's open transaction and returns
+     * the non-fatal warnings they produced (e.g. PostgreSQL {@code RAISE WARNING} / {@code RAISE
+     * NOTICE}). A statement that fails throws a {@link FeatureMutationHookException} (carrying any
+     * warnings collected before the failing statement), leaving the transaction open for rollback.
+     * Used by transaction-lifecycle hooks (session setup, pre-commit checks). The default
+     * implementation accepts an empty list as a no-op and otherwise throws {@link
+     * UnsupportedOperationException} for providers that cannot run native statements.
+     *
+     * @param statements the statements to execute, in order
+     * @return the collected warning messages across all statements, in execution order
+     */
+    default List<String> execute(List<String> statements) {
+      if (!statements.isEmpty()) {
+        throw new UnsupportedOperationException(
+            "Raw statement execution is not supported by this feature provider session");
+      }
+      return List.of();
+    }
+
     /** Commits all mutations performed against this session. Throws if already finalised. */
     void commit();
 


### PR DESCRIPTION
Add Session.execute(List<String>) to the FeatureTransactions.Session SPI so callers can run native statements on an open mutation transaction and receive the non-fatal SQL warnings they emit. This backs configurable per-transaction setup and pre-commit hooks in the OGC API transactions building block.

- FeatureTransactions.Session: new execute(List<String>) default; an empty list is a no-op, otherwise UnsupportedOperationException for providers that cannot run native statements.
- SqlSession / JdbcSqlSession: run each statement in order and collect the JDBC SQLWarning chain (e.g. PostgreSQL RAISE WARNING / RAISE NOTICE), returning it.
- On a statement failure throw FeatureMutationHookException, carrying the warnings collected before the failing statement so they survive the rollback path; this is an expected, configuration-driven outcome, not an illegal state.
- SqlMutationSession delegates to the SQL session.