### PR TITLE
fix schema-invalid GML for polygon rings when useSurfaceAndCurve is enabled

### DIFF
--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/GeometryEncoderGml.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/GeometryEncoderGml.java
@@ -495,9 +495,7 @@ public class GeometryEncoderGml implements GeometryVisitor<Void> {
       if (useSurfaceAndCurve) {
         writeStartTagObject(RING, true);
         writeStartTagProperty(CURVE_MEMBER);
-        writeStartTagDataType(LINE_STRING_SEGMENT);
-        writePositionList(ring.getValue().getCoordinates(), geometry.getAxes());
-        writeEndTag();
+        ring.accept(encodeAsEmbeddedGeometry.orElse(this));
         writeEndTag();
       } else {
         writeStartTagObject(LINEAR_RING, true);

--- a/xtraplatform-features-gml/src/test/groovy/de/ii/xtraplatform/features/gml/domain/GeometrySpec.groovy
+++ b/xtraplatform-features-gml/src/test/groovy/de/ii/xtraplatform/features/gml/domain/GeometrySpec.groovy
@@ -445,7 +445,7 @@ class GeometrySpec extends Specification {
         String gmlOut = sw.toString()
 
         then:
-        gmlOut == "<gml:Surface><gml:patches><gml:PolygonPatch><gml:exterior><gml:Ring><gml:curveMember><gml:LineStringSegment><gml:posList>0.0 0.0 0.0 1.0 1.0 1.0 0.0 0.0</gml:posList></gml:LineStringSegment></gml:curveMember></gml:Ring></gml:exterior></gml:PolygonPatch></gml:patches></gml:Surface>"
+        gmlOut == "<gml:Surface><gml:patches><gml:PolygonPatch><gml:exterior><gml:Ring><gml:curveMember><gml:Curve><gml:segments><gml:LineStringSegment><gml:posList>0.0 0.0 0.0 1.0 1.0 1.0 0.0 0.0</gml:posList></gml:LineStringSegment></gml:segments></gml:Curve></gml:curveMember></gml:Ring></gml:exterior></gml:PolygonPatch></gml:patches></gml:Surface>"
     }
 
     def 'CURVEPOLYGON XY with USE_SURFACE_RING_CURVE'() {


### PR DESCRIPTION
Plain polygons were encoded as Ring > curveMember > LineStringSegment, but gml:curveMember requires an element from the gml:AbstractCurve substitution group. The ring is now delegated to the geometry encoder, producing Ring > curveMember > Curve > segments > LineStringSegment, consistent with the existing curve-polygon path. Curve polygons were not affected.

- GeometryEncoderGml: delegate polygon rings to the embedded encoder in the USE_SURFACE_RING_CURVE branch
- GeometrySpec: expect the wrapped, schema-valid encoding