### PR TITLE
gml: decode properties mapped to XML element chains

### DIFF
--- a/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/CustomFunction.java
+++ b/xtraplatform-cql/src/main/java/de/ii/xtraplatform/cql/domain/CustomFunction.java
@@ -176,8 +176,8 @@ public interface CustomFunction {
   /**
    * A built-in function that is only meaningful within a query expression (a semi-join against a
    * result set defined by another query) and is encoded by a dedicated handler rather than a SQL
-   * template. Such a function therefore defines neither {@code expression} nor {@code expressions}.
-   * Not intended for user-defined functions.
+   * template. Such a function therefore defines neither `expression` nor `expressions`. Not
+   * intended for user-defined functions.
    */
   @Value.Default
   default boolean getQueryExpressionOnly() {

--- a/xtraplatform-crs/src/main/java/de/ii/xtraplatform/crs/domain/EpsgCrs.java
+++ b/xtraplatform-crs/src/main/java/de/ii/xtraplatform/crs/domain/EpsgCrs.java
@@ -102,13 +102,12 @@ public interface EpsgCrs {
 
   /**
    * An alternative identifier under which this CRS is known in a community (e.g. the AdV identifier
-   * {@code urn:adv:crs:ETRS89_UTM32} for EPSG:25832), declared on the entries of the {@code
-   * additionalCrs} option of the CRS building block. Unlike {@link #getUriOverride()} — which
-   * echoes the identifier a request used — the alternative URI is only used when a feature encoding
-   * renders CRS identifiers on the wire (e.g. the GML {@code srsName} with {@code srsNameStyle:
-   * TEMPLATE}) and when decoding such identifiers on input. Auxiliary, i.e., excluded from {@code
-   * equals()}/{@code hashCode()}: instances differing only in this attribute represent the same
-   * CRS.
+   * `urn:adv:crs:ETRS89_UTM32` for EPSG:25832), declared on the entries of the `additionalCrs`
+   * option of the CRS building block. Unlike `uriOverride`, which echoes the identifier a request
+   * used, the alternative URI is only used when a feature encoding renders CRS identifiers on the
+   * wire (e.g. the GML `srsName` with `srsNameStyle: TEMPLATE`) and when decoding such identifiers
+   * on input. Auxiliary, i.e., excluded from `equals()`/`hashCode()`: instances differing only in
+   * this attribute represent the same CRS.
    */
   @Value.Auxiliary
   Optional<String> getAlternativeUri();

--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGml.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGml.java
@@ -37,6 +37,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
@@ -85,9 +86,9 @@ import org.slf4j.LoggerFactory;
  * these routinely appear as children of a scalar property element. The decoder hardcodes {@link
  * #GMD_NS} and {@link #GCO_NS} as value-carrying namespaces: any element in those namespaces inside
  * a {@code VALUE_PROPERTY} is treated as a {@code VALUE_WRAPPER} around the property's scalar text,
- * no explicit {@code valueWrap} entry required. Wrappers in other namespaces (e.g. {@code
- * <adv:AX_LI_ProcessStep_Punktort_Description>}) still need explicit {@code valueWrap}
- * configuration on the input profile. A known restriction of the GML building block.
+ * no explicit {@code xmlPaths} entry required. Wrappers in other namespaces (e.g. {@code
+ * <adv:AX_LI_ProcessStep_Punktort_Description>}) still need explicit {@code xmlPaths} configuration
+ * on the input profile. A known restriction of the GML building block.
  */
 public class FeatureTokenDecoderGml
     extends FeatureTokenDecoderSimple<
@@ -104,7 +105,7 @@ public class FeatureTokenDecoderGml
    * instead uses object elements that directly carry text content (e.g. {@code
    * <gco:CharacterString>}, {@code <gmd:CI_RoleCode>}). When such an element appears as a child of
    * a scalar property element the decoder treats it as a value wrapper around the scalar text, even
-   * without an explicit {@code valueWrap} entry. Any other external namespace that follows the same
+   * without an explicit {@code xmlPaths} entry. Any other external namespace that follows the same
    * convention needs a similar entry here when the need arises — a known restriction of the GML
    * building block.
    */
@@ -144,9 +145,9 @@ public class FeatureTokenDecoderGml
    * Maps each property's {@link FeatureSchema#getFullPathAsString()} to the equivalent path with
    * each segment replaced by the property's {@code alias} (falling back to the segment name when no
    * alias is set). The encoder applies {@code alias} as a {@code rename} transformation before
-   * consulting {@link FeatureTokenDecoderGmlInputProfile#getValueWrap()}, so its lookup key is the
+   * consulting {@link FeatureTokenDecoderGmlInputProfile#getXmlPaths()}, so its lookup key is the
    * alias-form path. The decoder, which sees the untransformed schema, uses this map to consult
-   * {@code valueWrap} under the same key the encoder writes — keeping a single YAML convention
+   * {@code xmlPaths} under the same key the encoder writes — keeping a single YAML convention
    * (alias-form keys) working symmetrically for read and write. Empty (no aliases declared) when
    * {@code useAlias} is off or no property carries an alias.
    */
@@ -157,6 +158,22 @@ public class FeatureTokenDecoderGml
    * schema's {@code crsVariants} declaration by {@link #buildGeometryVariants}.
    */
   private final Map<String, GmlGeometryVariants> geometryVariantsCache = new HashMap<>();
+
+  /**
+   * The {@code xmlPaths} chains that do <em>not</em> start with the mapped property's own element,
+   * i.e. those that represent a property as a nested element structure (a flat property encoded as
+   * an ancestor chain, e.g. {@code lzi_beg} as {@code
+   * lebenszeitintervall/AA_Lebenszeitintervall/beginnt}). Keyed by the full path of the schema that
+   * owns the property — {@code ""} for the feature root, the object property's path for a member of
+   * an object / object array — so a chain is only considered where its property lives.
+   *
+   * <p>Chains whose first segment matches the property's own name/alias are absent here: on the
+   * wire those look exactly like a property element with wrapped content, which {@link
+   * #lookupChild(FeatureSchema, String, String)} resolves directly and {@link
+   * #isValueWrapped(FeatureSchema)} handles — the shape produced by the option's value-wrapping use
+   * (ISO 19139 type elements).
+   */
+  private final Map<String, List<XmlPathChain>> structuralChainsByOwnerPath;
 
   private int depth = 0;
   private boolean inFeature = false;
@@ -201,14 +218,21 @@ public class FeatureTokenDecoderGml
      */
     OBJECT_ELEMENT,
     /**
-     * Wrapper element interposed by the encoder's {@code valueWrap} option between a {@link
+     * Wrapper element interposed by the encoder's {@code xmlPaths} option between a {@link
      * #VALUE_PROPERTY} and its scalar text (e.g. {@code <prop><Wrap1><Wrap2>v</Wrap2></Wrap1>
      * </prop>}). Carries no schema meaning; its purpose is to keep the character buffer alive
      * across the wrappers' end-elements so the enclosing VALUE_PROPERTY can read the inner text on
      * its own end. Only pushed when the enclosing VALUE_PROPERTY's {@code fullPathAsString} is
-     * listed in {@link FeatureTokenDecoderGmlInputProfile#getValueWrap()}.
+     * listed in {@link FeatureTokenDecoderGmlInputProfile#getXmlPaths()}.
      */
     VALUE_WRAPPER,
+    /**
+     * Element of an {@code xmlPaths} chain that represents a property as a nested element structure
+     * (see {@link #structuralChainsByOwnerPath}). Contributes no path segment of its own; its child
+     * elements continue the chain until its innermost segment is reached, which resolves to the
+     * mapped property and is decoded as a {@link #VALUE_PROPERTY}.
+     */
+    XML_PATH_CHAIN,
     /** Element with no matching schema property; descendants are ignored. */
     UNKNOWN
   }
@@ -261,7 +285,7 @@ public class FeatureTokenDecoderGml
 
     /**
      * For VALUE_PROPERTY: set to {@code true} when the property's {@code fullPathAsString} is
-     * listed in {@link FeatureTokenDecoderGmlInputProfile#getValueWrap()}. Children that appear
+     * listed in {@link FeatureTokenDecoderGmlInputProfile#getXmlPaths()}. Children that appear
      * inside such a frame are pushed as {@link FrameKind#VALUE_WRAPPER}s so that wrapper
      * end-elements do not flush the character buffer before the scalar text is emitted on the
      * VALUE_PROPERTY's own end.
@@ -284,6 +308,31 @@ public class FeatureTokenDecoderGml
      * affect its parent's open array.
      */
     String openArrayChildPath;
+
+    /**
+     * For XML_PATH_CHAIN: the chains still viable at this point — those whose segments matched
+     * every element consumed so far. Narrowed as the chain is descended.
+     */
+    List<XmlPathChain> chainCandidates;
+
+    /**
+     * For XML_PATH_CHAIN: index of the segment expected for the next child element. Advances past
+     * an injected empty-element segment once that segment has been consumed as a sibling.
+     */
+    int chainIndex;
+
+    /**
+     * For XML_PATH_CHAIN: the property whose ARRAY the enclosing container already opened because
+     * the whole chain repeats. The innermost segment must not bracket that property a second time.
+     */
+    String chainContainerArrayPath;
+
+    /**
+     * For XML_PATH_CHAIN: path-tracker depth of the container the chain starts in, so the property
+     * the chain resolves to is emitted at that container's child depth — the chain's own elements
+     * contribute no path segments.
+     */
+    int chainContainerPathDepth;
 
     private Frame(
         FrameKind kind,
@@ -316,6 +365,15 @@ public class FeatureTokenDecoderGml
 
     static Frame valueWrapper() {
       return new Frame(FrameKind.VALUE_WRAPPER, null, null, null, -1);
+    }
+
+    static Frame xmlPathChain(
+        List<XmlPathChain> candidates, int chainIndex, int containerPathDepth) {
+      Frame frame = new Frame(FrameKind.XML_PATH_CHAIN, null, null, null, -1);
+      frame.chainCandidates = candidates;
+      frame.chainIndex = chainIndex;
+      frame.chainContainerPathDepth = containerPathDepth;
+      return frame;
     }
 
     static Frame unknown() {
@@ -369,6 +427,8 @@ public class FeatureTokenDecoderGml
       this.aliasFormPathByPropertyPath = Map.of();
     }
 
+    this.structuralChainsByOwnerPath = collectStructuralChains();
+
     try {
       this.parser = new InputFactoryImpl().createAsyncFor(new byte[0]);
     } catch (XMLStreamException e) {
@@ -378,22 +438,148 @@ public class FeatureTokenDecoderGml
 
   /**
    * Mirrors the encoder side, which queries {@link
-   * FeatureTokenDecoderGmlInputProfile#getValueWrap()} after {@code alias → rename} injection —
-   * i.e. by the alias-form path. We check both the untransformed property path and the alias-form
-   * path so a YAML config keyed by either form (alias path when {@code useAlias: true}, or the bare
-   * property path) is recognised.
+   * FeatureTokenDecoderGmlInputProfile#getXmlPaths()} after {@code alias → rename} injection — i.e.
+   * by the alias-form path. We check both the untransformed property path and the alias-form path
+   * so a YAML config keyed by either form (alias path when {@code useAlias: true}, or the bare
+   * property path) is recognised. An {@code xmlPaths} chain is the complete element chain including
+   * the property element as its first segment; only a chain with additional inner segments wraps
+   * the value, so single-segment chains do not flag value wrapping.
    */
   private boolean isValueWrapped(FeatureSchema prop) {
-    Map<String, List<String>> valueWrap = inputProfile.getValueWrap();
-    if (valueWrap.isEmpty()) {
+    Map<String, List<String>> xmlPaths = inputProfile.getXmlPaths();
+    if (xmlPaths.isEmpty()) {
       return false;
     }
     String path = prop.getFullPathAsString();
-    if (valueWrap.containsKey(path)) {
-      return true;
+    List<String> chain = xmlPaths.get(path);
+    if (chain == null) {
+      String aliasPath = aliasFormPathByPropertyPath.get(path);
+      chain = aliasPath == null ? null : xmlPaths.get(aliasPath);
     }
-    String aliasPath = aliasFormPathByPropertyPath.get(path);
-    return aliasPath != null && valueWrap.containsKey(aliasPath);
+    return chain != null && chain.size() > 1;
+  }
+
+  /**
+   * One segment of a parsed {@code xmlPaths} chain: the element's local name, the namespace URI
+   * expected for it ({@code null} when none can be resolved — the segment then matches on local
+   * name alone), and whether the encoder injects it as an empty element (configured with a trailing
+   * {@code /}). Attribute predicates are output-only and are dropped here.
+   */
+  private static final class XmlPathSegment {
+    final String localName;
+    final String namespaceUri;
+    final boolean emptyElement;
+
+    XmlPathSegment(String localName, String namespaceUri, boolean emptyElement) {
+      this.localName = localName;
+      this.namespaceUri = namespaceUri;
+      this.emptyElement = emptyElement;
+    }
+
+    boolean matches(String wireLocalName, String wireNamespaceUri) {
+      return localName.equals(wireLocalName)
+          && (namespaceUri == null || namespaceUri.equals(wireNamespaceUri));
+    }
+  }
+
+  /** A property together with the parsed element chain that represents it on the wire. */
+  private static final class XmlPathChain {
+    final FeatureSchema property;
+    final List<XmlPathSegment> segments;
+
+    XmlPathChain(FeatureSchema property, List<XmlPathSegment> segments) {
+      this.property = property;
+      this.segments = segments;
+    }
+  }
+
+  /**
+   * Builds {@link #structuralChainsByOwnerPath} by walking the schema and parsing every {@code
+   * xmlPaths} entry (looked up by the property's technical path or its alias-form path) whose first
+   * segment is not the property's own element.
+   */
+  private Map<String, List<XmlPathChain>> collectStructuralChains() {
+    if (inputProfile.getXmlPaths().isEmpty()) {
+      return Map.of();
+    }
+    Map<String, List<XmlPathChain>> chains = new LinkedHashMap<>();
+    collectStructuralChains(featureSchema, "", chains);
+    return chains;
+  }
+
+  private void collectStructuralChains(
+      FeatureSchema owner, String ownerPath, Map<String, List<XmlPathChain>> chains) {
+    for (FeatureSchema property : owner.getProperties()) {
+      String path = property.getFullPathAsString();
+      List<String> configured = inputProfile.getXmlPaths().get(path);
+      if (configured == null) {
+        String aliasPath = aliasFormPathByPropertyPath.get(path);
+        configured = aliasPath == null ? null : inputProfile.getXmlPaths().get(aliasPath);
+      }
+      if (configured != null && !configured.isEmpty()) {
+        List<XmlPathSegment> segments =
+            configured.stream().map(this::parseXmlPathSegment).collect(Collectors.toList());
+        String propertyElement = stripPrefix(propertyKey(property, inputProfile.getUseAlias()));
+        if (!segments.get(0).localName.equals(propertyElement)) {
+          chains
+              .computeIfAbsent(ownerPath, k -> new ArrayList<>())
+              .add(new XmlPathChain(property, List.copyOf(segments)));
+        }
+      }
+      if (!property.getProperties().isEmpty()) {
+        collectStructuralChains(property, path, chains);
+      }
+    }
+  }
+
+  /**
+   * Parses one configured chain segment. Mirrors the encoder's grammar {@code
+   * name([attribute=value])*'/'?}: the attribute predicates only affect output and are dropped, a
+   * trailing {@code /} marks an injected empty element, and a {@code prefix:} resolves to the
+   * expected namespace URI (falling back to the input profile's {@code defaultNamespace}).
+   */
+  private XmlPathSegment parseXmlPathSegment(String configured) {
+    String segment = configured.trim();
+    boolean emptyElement = segment.endsWith("/");
+    if (emptyElement) {
+      segment = segment.substring(0, segment.length() - 1).trim();
+    }
+    int bracket = segment.indexOf('[');
+    if (bracket >= 0) {
+      segment = segment.substring(0, bracket).trim();
+    }
+    int colon = segment.indexOf(':');
+    String namespaceUri;
+    if (colon > 0) {
+      namespaceUri = namespaceNormalizer.getNamespaceURI(segment.substring(0, colon));
+      segment = segment.substring(colon + 1);
+    } else {
+      String defaultPrefix = inputProfile.getDefaultNamespace();
+      namespaceUri =
+          defaultPrefix == null || defaultPrefix.isEmpty()
+              ? null
+              : namespaceNormalizer.getNamespaceURI(defaultPrefix);
+    }
+    return new XmlPathSegment(segment, namespaceUri, emptyElement);
+  }
+
+  /**
+   * The chains of {@code owner} whose first segment matches the wire element, i.e. the mapped
+   * properties this element may introduce. More than one chain matches when several properties
+   * share leading elements (the encoder's wrapper merging, e.g. {@code lzi_beg} and {@code lzi_end}
+   * inside one {@code AA_Lebenszeitintervall}); the ambiguity is resolved segment by segment as the
+   * chain is descended.
+   */
+  private List<XmlPathChain> matchStructuralChainStart(
+      FeatureSchema owner, String wireLocalName, String wireNamespaceUri) {
+    List<XmlPathChain> candidates =
+        structuralChainsByOwnerPath.get(owner == featureSchema ? "" : owner.getFullPathAsString());
+    if (candidates == null) {
+      return List.of();
+    }
+    return candidates.stream()
+        .filter(c -> c.segments.get(0).matches(wireLocalName, wireNamespaceUri))
+        .collect(Collectors.toList());
   }
 
   private static void collectAliasFormPaths(
@@ -586,6 +772,12 @@ public class FeatureTokenDecoderGml
       return false;
     }
 
+    if (parent != null && parent.kind == FrameKind.XML_PATH_CHAIN) {
+      continueStructuralChain(parent);
+      depth++;
+      return false;
+    }
+
     FeatureSchema lookupOwner;
     int parentPathDepth;
     if (parent == null) {
@@ -602,11 +794,11 @@ public class FeatureTokenDecoderGml
       // Inside a VALUE_PROPERTY / VALUE_WRAPPER / GEOMETRY_PROPERTY / UNKNOWN frame — descendants
       // carry no schema meaning. (Per GML's alternation rule a scalar property has only text
       // content; if we see an element here it is either unsupported mixed content or an
-      // already-skipped subtree.) Exceptions: (a) the encoder's valueWrap option produces a
+      // already-skipped subtree.) Exceptions: (a) the encoder's xmlPaths option produces a
       // wrapper-element chain around the scalar text of a VALUE_PROPERTY — push VALUE_WRAPPER so
       // the character buffer survives the wrappers' end-elements; (b) gmd/gco object elements
       // (ISO 19115) carry text directly and routinely appear inside a property element — treat
-      // them as value wrappers without requiring an explicit valueWrap entry. Once inside a
+      // them as value wrappers without requiring an explicit xmlPaths entry. Once inside a
       // VALUE_WRAPPER, the chain continues regardless of the inner element's namespace.
       frames.push(isValueWrapChainElement() ? Frame.valueWrapper() : Frame.unknown());
       depth++;
@@ -617,15 +809,31 @@ public class FeatureTokenDecoderGml
     String namespaceUri = parser.getNamespaceURI();
     Optional<FeatureSchema> propOpt = lookupChild(lookupOwner, localName, namespaceUri);
 
+    // An element that matches no property may start an xmlPaths chain that represents a property as
+    // a nested element structure. When exactly one chain matches, its property also participates in
+    // array bracketing below — repeating the whole chain is how a multi-valued mapped property
+    // appears on the wire.
+    List<XmlPathChain> chainStart =
+        propOpt.isPresent()
+            ? List.of()
+            : matchStructuralChainStart(
+                lookupOwner, localName, namespaceUri == null ? "" : namespaceUri);
+
     // Array bracketing fires at any container level: the feature root (parent == null) and every
     // OBJECT_ELEMENT (where the inner object element acts as the container for its child
     // properties). The root level uses {@code currentArrayPath}; each OBJECT_ELEMENT frame
     // carries its own {@code openArrayChildPath}. The open array at this level closes when the
     // next sibling property has a different name.
     boolean isArrayContainer = parent == null || parent.kind == FrameKind.OBJECT_ELEMENT;
+    Optional<FeatureSchema> arrayProp =
+        propOpt.or(
+            () ->
+                chainStart.size() == 1
+                    ? Optional.of(chainStart.get(0).property)
+                    : Optional.empty());
     if (isArrayContainer) {
       String containerArrayPath = parent == null ? currentArrayPath : parent.openArrayChildPath;
-      String childPathSegment = propOpt.map(FeatureSchema::getName).orElse(null);
+      String childPathSegment = arrayProp.map(FeatureSchema::getName).orElse(null);
       if (containerArrayPath != null && !containerArrayPath.equals(childPathSegment)) {
         downstream.onArrayEnd(context);
         if (parent == null) {
@@ -634,6 +842,31 @@ public class FeatureTokenDecoderGml
           parent.openArrayChildPath = null;
         }
       }
+    }
+
+    if (propOpt.isEmpty() && !chainStart.isEmpty()) {
+      // Open the ARRAY bracket for a multi-valued mapped property before its first chain: the
+      // chain's elements contribute no path segment, so the bracket is anchored at the property's
+      // own path, one level below the container.
+      FeatureSchema chainProp = chainStart.size() == 1 ? chainStart.get(0).property : null;
+      if (isArrayContainer && chainProp != null && chainProp.isArray()) {
+        String containerArrayPath = parent == null ? currentArrayPath : parent.openArrayChildPath;
+        if (containerArrayPath == null) {
+          context.pathTracker().track(chainProp.getName(), parentPathDepth + 1);
+          downstream.onArrayStart(context);
+          if (parent == null) {
+            currentArrayPath = chainProp.getName();
+          } else {
+            parent.openArrayChildPath = chainProp.getName();
+          }
+        }
+      }
+      Frame chainFrame = Frame.xmlPathChain(chainStart, 1, parentPathDepth);
+      chainFrame.chainContainerArrayPath =
+          parent == null ? currentArrayPath : parent.openArrayChildPath;
+      frames.push(chainFrame);
+      depth++;
+      return false;
     }
 
     if (propOpt.isEmpty()) {
@@ -684,20 +917,7 @@ public class FeatureTokenDecoderGml
       depth++;
       return waiting;
     } else if (prop.isValue()) {
-      Frame frame = Frame.valueProperty(prop, segment, segmentPathDepth);
-      frame.nilOnCurrent = readXsiNil();
-      frame.pendingXlinkHrefValue = readXlinkHrefAsValue(prop);
-      if (frame.pendingXlinkHrefValue == null
-          && prop.getValueType().orElse(prop.getType()) == Type.STRING) {
-        String raw = readRawXlinkHref();
-        frame.pendingXlinkHrefFallback =
-            raw == null
-                ? null
-                : applyReverseTemplate(inputProfile.getFeatureRefTemplate(), raw).orElse(raw);
-      }
-      frame.valueWrapped = isValueWrapped(prop);
-      validateUom(prop);
-      frames.push(frame);
+      frames.push(createValueFrame(prop, segment, segmentPathDepth));
     } else if (prop.isObject()) {
       // OBJECT pair anchoring: for non-array OBJECT_PROPERTYs and for FEATURE_REF-as-OBJECT
       // (wrap=OBJECT / OBJECT_ARRAY where the wire is a self-closing prop element with
@@ -737,6 +957,120 @@ public class FeatureTokenDecoderGml
 
     depth++;
     return false;
+  }
+
+  /**
+   * Builds the VALUE_PROPERTY frame for a scalar property whose element has just been entered,
+   * reading the attribute-borne alternatives to character content ({@code xsi:nil}, {@code
+   * xlink:href}) and validating {@code uom}. Shared by the direct property match and the resolution
+   * of an {@code xmlPaths} chain's innermost segment.
+   */
+  private Frame createValueFrame(FeatureSchema prop, String segment, int pathDepth) {
+    Frame frame = Frame.valueProperty(prop, segment, pathDepth);
+    frame.nilOnCurrent = readXsiNil();
+    frame.pendingXlinkHrefValue = readXlinkHrefAsValue(prop);
+    if (frame.pendingXlinkHrefValue == null
+        && prop.getValueType().orElse(prop.getType()) == Type.STRING) {
+      String raw = readRawXlinkHref();
+      frame.pendingXlinkHrefFallback =
+          raw == null
+              ? null
+              : applyReverseTemplate(inputProfile.getFeatureRefTemplate(), raw).orElse(raw);
+    }
+    frame.valueWrapped = isValueWrapped(prop);
+    validateUom(prop);
+    return frame;
+  }
+
+  /**
+   * Continues an {@code xmlPaths} chain inside {@code parent}: matches the current wire element
+   * against the segment the still-viable chains expect, and either descends further (another chain
+   * element), resolves the property (the innermost segment reached — decoded as a VALUE_PROPERTY at
+   * the chain's container depth), or skips an injected empty element. An element that matches no
+   * candidate is pushed as UNKNOWN, so unmapped extra content inside a chain is ignored as
+   * elsewhere.
+   */
+  // Close the ARRAY a chain frame opened for a repeated innermost element. The path tracker may
+  // have moved on to another property, so re-track the array property's own path first — that is
+  // where ARRAY_END belongs.
+  private void closeChainArray(Frame chain) {
+    if (chain.openArrayChildPath != null) {
+      context.pathTracker().track(chain.openArrayChildPath, chain.chainContainerPathDepth + 1);
+      downstream.onArrayEnd(context);
+      chain.openArrayChildPath = null;
+    }
+  }
+
+  private void continueStructuralChain(Frame parent) {
+    String wireLocalName = parser.getLocalName();
+    String wireNamespaceUri = parser.getNamespaceURI() == null ? "" : parser.getNamespaceURI();
+
+    // The expected segment index may have to advance past injected empty-element segments: the
+    // encoder writes them as siblings of the following segment, and a client may omit them.
+    List<XmlPathChain> matched = new ArrayList<>(parent.chainCandidates.size());
+    int matchedIndex = -1;
+    boolean matchedEmptySegment = false;
+    for (XmlPathChain candidate : parent.chainCandidates) {
+      for (int index = parent.chainIndex; index < candidate.segments.size(); index++) {
+        XmlPathSegment segment = candidate.segments.get(index);
+        if (segment.matches(wireLocalName, wireNamespaceUri)) {
+          if (matchedIndex < 0 || index == matchedIndex) {
+            matchedIndex = index;
+            matchedEmptySegment = segment.emptyElement;
+            matched.add(candidate);
+          }
+          break;
+        }
+        if (!segment.emptyElement) {
+          break;
+        }
+      }
+    }
+
+    if (matched.isEmpty()) {
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Skipping <{}>: no xmlPaths segment matches.", wireLocalName);
+      }
+      frames.push(Frame.unknown());
+      return;
+    }
+
+    if (matchedEmptySegment) {
+      // An injected constant element (e.g. the ISO 19139 valueUnit): it carries no value, and the
+      // chain continues with the next segment on the following sibling.
+      parent.chainIndex = matchedIndex + 1;
+      frames.push(Frame.unknown());
+      return;
+    }
+
+    XmlPathChain resolved = matched.get(0);
+    if (matchedIndex == resolved.segments.size() - 1) {
+      FeatureSchema prop = resolved.property;
+      String segment = prop.getName();
+      int pathDepth = parent.chainContainerPathDepth + 1;
+      // The innermost element of a chain may repeat inside one wrapper — that is how a
+      // multi-valued property arrives. Its values need an ARRAY bracket anchored at the
+      // property's own path, because the chain's elements contribute no path segment. The
+      // bracket stays open while the same property repeats and closes when another property
+      // starts or the wrapper ends.
+      if (!Objects.equals(parent.openArrayChildPath, segment)
+          && !Objects.equals(parent.chainContainerArrayPath, segment)) {
+        closeChainArray(parent);
+        if (prop.isArray()) {
+          context.pathTracker().track(segment, pathDepth);
+          downstream.onArrayStart(context);
+          parent.openArrayChildPath = segment;
+        }
+      }
+      context.pathTracker().track(segment, pathDepth);
+      frames.push(createValueFrame(prop, segment, pathDepth));
+      return;
+    }
+
+    closeChainArray(parent);
+    Frame nested = Frame.xmlPathChain(matched, matchedIndex + 1, parent.chainContainerPathDepth);
+    nested.chainContainerArrayPath = parent.chainContainerArrayPath;
+    frames.push(nested);
   }
 
   private void onEndElement() throws XMLStreamException, java.io.IOException {
@@ -814,6 +1148,8 @@ public class FeatureTokenDecoderGml
       if (!arrayOfObjects) {
         downstream.onObjectEnd(context);
       }
+    } else if (frame != null && frame.kind == FrameKind.XML_PATH_CHAIN) {
+      closeChainArray(frame);
     } else if (frame != null && frame.kind == FrameKind.OBJECT_ELEMENT) {
       // Close any array still open inside this OBJECT_ELEMENT before bookkeeping at the enclosing
       // OBJECT_PROPERTY level. The path tracker still points at the array property's path from
@@ -1279,7 +1615,7 @@ public class FeatureTokenDecoderGml
   /**
    * Whether the current START_ELEMENT is part of a value-wrap chain: its parent frame is a {@link
    * FrameKind#VALUE_WRAPPER}, or a {@link FrameKind#VALUE_PROPERTY} whose path is listed in {@code
-   * valueWrap} or whose child lives in an ISO 19115 content namespace ({@code gmd}/{@code gco}).
+   * xmlPaths} or whose child lives in an ISO 19115 content namespace ({@code gmd}/{@code gco}).
    * Such elements carry no schema meaning — they only wrap the property's scalar text — so they are
    * pushed as {@link Frame#valueWrapper()} and exempt from {@link #rejectXsiType()}: ISO 19139
    * requires typed values like {@code <gco:Record xsi:type="gml:doubleList">} inside {@code
@@ -1290,6 +1626,7 @@ public class FeatureTokenDecoderGml
     Frame parent = frames.peek();
     return parent != null
         && (parent.kind == FrameKind.VALUE_WRAPPER
+            || parent.kind == FrameKind.XML_PATH_CHAIN
             || (parent.kind == FrameKind.VALUE_PROPERTY
                 && (parent.valueWrapped || isExternalContentNamespace(parser.getNamespaceURI()))));
   }
@@ -1301,7 +1638,7 @@ public class FeatureTokenDecoderGml
    * appeared. Elements inside a value-wrap chain (see {@link #isValueWrapChainElement()}) are
    * exempt: there {@code xsi:type} types the content of an anyType value element (ISO 19139 {@code
    * gco:Record}) and is dropped on input; the encoder regenerates it from the attributes declared
-   * on the {@code valueWrap} chain entry.
+   * on the {@code xmlPaths} chain segment.
    */
   private void rejectXsiType() {
     for (int i = 0; i < parser.getAttributeCount(); i++) {

--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGmlInputProfile.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGmlInputProfile.java
@@ -164,7 +164,15 @@ public interface FeatureTokenDecoderGmlInputProfile {
 
   List<String> getXmlAttributes();
 
-  Map<String, List<String>> getValueWrap();
+  /**
+   * Reverse of {@code GmlConfiguration#xmlPaths}: per property (keyed by property path, in
+   * technical or alias form), the complete element chain the encoder writes for it — the first
+   * segment is the property element, the innermost segment holds the value. On input, a property
+   * whose chain has inner segments is treated as value-wrapped: elements between the property
+   * element and the character data are consumed transparently (attributes on them are dropped,
+   * injected empty elements are skipped).
+   */
+  Map<String, List<String>> getXmlPaths();
 
   /**
    * Reverse of {@code GmlConfiguration#objectTypeSuffixedProperties}: the property id (technical

--- a/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/GeometryDecoderGml.java
+++ b/xtraplatform-features-gml/src/main/java/de/ii/xtraplatform/features/gml/domain/GeometryDecoderGml.java
@@ -160,8 +160,8 @@ public class GeometryDecoderGml extends AbstractGeometryDecoder {
   /**
    * @param srsNameMappings reverse-mapping from {@code srsName} URI/URN forms to {@link EpsgCrs};
    *     consulted before the built-in EPSG / OGC URN parsers and intended to resolve
-   *     application-profile forms (e.g. ALKIS NAS uses {@code urn:adv:crs:DE_DHDN_3GK2_NW101}) that
-   *     the built-in parsers cannot handle.
+   *     application-profile forms (e.g. ALKIS NAS uses {@code urn:adv:crs:DE_DHDN_3GK3}) that the
+   *     built-in parsers cannot handle.
    */
   public GeometryDecoderGml(Map<String, EpsgCrs> srsNameMappings) {
     this(srsNameMappings, Set.of());

--- a/xtraplatform-features-gml/src/test/groovy/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGmlSpec.groovy
+++ b/xtraplatform-features-gml/src/test/groovy/de/ii/xtraplatform/features/gml/domain/FeatureTokenDecoderGmlSpec.groovy
@@ -22,9 +22,6 @@ import de.ii.xtraplatform.features.domain.SchemaBase
 import de.ii.xtraplatform.features.domain.SchemaMapping
 import de.ii.xtraplatform.features.domain.pipeline.FeatureEventHandlerSimple
 import de.ii.xtraplatform.features.domain.pipeline.FeatureTokenDecoderSimple
-import de.ii.xtraplatform.features.gml.domain.FeatureTokenDecoderGmlInputProfile
-import de.ii.xtraplatform.features.gml.domain.ImmutableFeatureTokenDecoderGmlInputProfile
-import de.ii.xtraplatform.features.gml.domain.ImmutableVariableObjectName
 import de.ii.xtraplatform.geometries.domain.Geometry
 import de.ii.xtraplatform.geometries.domain.GeometryType
 import de.ii.xtraplatform.streams.app.ReactiveRx
@@ -1745,12 +1742,12 @@ class FeatureTokenDecoderGmlSpec extends Specification {
     }
 
     /**
-     * AX_Flurstueck slice for the valueWrap reverse-mapping checks. {@code lzi_beg} mirrors
+     * AX_Flurstueck slice for the xmlPaths reverse-mapping checks. {@code lzi_beg} mirrors
      * the AA_Objekt {@code lebenszeitintervall} property: a DATETIME with SQL column {@code
      * lzi__beg}, label {@code lebenszeitintervall_beginnt} and alias {@code
      * lebenszeitintervall}. The encoder wraps the scalar value in {@code
      * <AA_Lebenszeitintervall><beginnt>…</beginnt></AA_Lebenszeitintervall>}, matching the
-     * {@code valueWrap} example in {@code GmlConfiguration}.
+     * {@code xmlPaths} example in {@code GmlConfiguration}.
      */
     static FeatureSchema axFlurstueckWithLifeCycleSchema() {
         new ImmutableFeatureSchema.Builder()
@@ -1773,14 +1770,14 @@ class FeatureTokenDecoderGmlSpec extends Specification {
                 .build()
     }
 
-    def 'valueWrap reverse-maps a wrapped scalar back to the property source path'() {
+    def 'xmlPaths reverse-maps a wrapped scalar back to the property source path'() {
         given:
         // Encoder shape: <adv:lebenszeitintervall> (alias-named property element) wraps an
         // <adv:AA_Lebenszeitintervall><adv:beginnt>…</adv:beginnt></adv:AA_Lebenszeitintervall>
         // chain around the scalar. Reverse mapping must surface the inner text at lzi__beg.
         def profile = ImmutableFeatureTokenDecoderGmlInputProfile.builder()
                 .useAlias(true)
-                .putValueWrap("lzi_beg", ["AA_Lebenszeitintervall", "beginnt"])
+                .putXmlPaths("lzi_beg", ["lebenszeitintervall", "AA_Lebenszeitintervall", "beginnt"])
                 .build()
         def decoder = newDecoder(axFlurstueckWithLifeCycleSchema(), profile)
         def xml = """<adv:AX_Flurstueck xmlns:adv="${ADV_NS}"
@@ -1800,14 +1797,14 @@ class FeatureTokenDecoderGmlSpec extends Specification {
         valueAtPath(tokens, ["lzi_beg"]) == "2010-09-14T11:54:36Z"
     }
 
-    def 'a sibling after a valueWrap chain still resolves at its own source path'() {
+    def 'a sibling after a xmlPaths chain still resolves at its own source path'() {
         given:
         // Path tracker must shorten back to the feature root once the wrapper chain closes, so
         // the following <adv:flurstueckskennzeichen> sibling lands at fsk, not at a stale path
         // left behind by the inner <adv:beginnt> wrapper.
         def profile = ImmutableFeatureTokenDecoderGmlInputProfile.builder()
                 .useAlias(true)
-                .putValueWrap("lzi_beg", ["AA_Lebenszeitintervall", "beginnt"])
+                .putXmlPaths("lzi_beg", ["lebenszeitintervall", "AA_Lebenszeitintervall", "beginnt"])
                 .build()
         def decoder = newDecoder(axFlurstueckWithLifeCycleSchema(), profile)
         def xml = """<adv:AX_Flurstueck xmlns:adv="${ADV_NS}"
@@ -1831,7 +1828,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
 
     def 'an unconfigured wrapped scalar is not surfaced (no permissive fallback)'() {
         given:
-        // valueWrap is gated on configuration: without an entry, wrapper elements inside a
+        // xmlPaths is gated on configuration: without an entry, wrapper elements inside a
         // VALUE_PROPERTY are treated as unknown descendants and the inner text is not emitted.
         // This matches the encoder side, which only wraps when the option is set.
         def decoder = newDecoder(axFlurstueckWithLifeCycleSchema(), useAliasProfile())
@@ -1965,7 +1962,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
     /**
      * NAS-shaped namespace profile: AX_PunktortAU / AX_DQPunktort fall back to the default adv
      * namespace, the four ISO 19115 object types (LI_Lineage, LI_ProcessStep, LI_Source,
-     * CI_ResponsibleParty) are in gmd. The {@code valueWrap} entries declare the two adv-
+     * CI_ResponsibleParty) are in gmd. The {@code xmlPaths} entries declare the two adv-
      * namespaced content-carrying wrappers that the encoder writes around two of the
      * LI_ProcessStep scalar children; gmd/gco wrappers (gco:DateTime, gco:CharacterString,
      * gmd:CI_RoleCode) are auto-detected by the decoder and need no entry here.
@@ -1978,8 +1975,8 @@ class FeatureTokenDecoderGmlSpec extends Specification {
                 .putObjectTypeNamespaces("LI_ProcessStep", "gmd")
                 .putObjectTypeNamespaces("LI_Source", "gmd")
                 .putObjectTypeNamespaces("CI_ResponsibleParty", "gmd")
-                .putValueWrap("qag.dpl.prs.des", ["AX_LI_ProcessStep_Punktort_Description"])
-                .putValueWrap("qag.dpl.prs.src.des", ["AX_Datenerhebung_Punktort"])
+                .putXmlPaths("qag.dpl.prs.des", ["gmd:description", "AX_LI_ProcessStep_Punktort_Description"])
+                .putXmlPaths("qag.dpl.prs.src.des", ["gmd:description", "AX_Datenerhebung_Punktort"])
                 .build()
     }
 
@@ -2019,12 +2016,12 @@ class FeatureTokenDecoderGmlSpec extends Specification {
         // LI_Source) is in gmd, with leaf values wrapped in adv-namespaced or gmd/gco
         // content-carrying objects:
         //   - description (LI_ProcessStep) wraps <adv:AX_LI_ProcessStep_Punktort_Description>
-        //     — adv namespace, requires explicit valueWrap config
+        //     — adv namespace, requires explicit xmlPaths config
         //   - dateTime wraps <gco:DateTime> — gmd/gco auto-detected
         //   - organisationName wraps <gco:CharacterString> — auto-detected
         //   - role wraps <gmd:CI_RoleCode codeListValue=…> — auto-detected; text content used
         //     (rol has a codelist constraint, but the gmd text path wins; see the focused test below)
-        //   - source/description wraps <adv:AX_Datenerhebung_Punktort> — explicit valueWrap
+        //   - source/description wraps <adv:AX_Datenerhebung_Punktort> — explicit xmlPaths
         // The sibling <adv:genauigkeitsstufe> at AX_DQPunktort level exercises a scalar that
         // sits next to the deep dpl subtree.
         def decoder = newPunktortAuDecoder(nasNamespaceProfile())
@@ -2690,7 +2687,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
     //   - defaultNamespace pointing at that "aaa" prefix
     //   - useAlias: true with mixed-namespace inner elements (adv + gmd/gco) reached via
     //     objectTypeNamespaces for the ISO 19115 object types
-    //   - valueWrap entries keyed both by alias path (lebenszeitintervall) and by property-name
+    //   - xmlPaths entries keyed both by alias path (lebenszeitintervall) and by property-name
     //     path (qag.dpl.prs.des / qag.dpl.prs.src.des), which are the two key shapes the decoder
     //     recognises
     //   - codelistUriTemplate and featureRefTemplate so that xlink:href on adv:anlass and
@@ -2714,7 +2711,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
      * AX_Gebaeude slice covering every property in {@code src/test/resources/nas/AX_Gebaeude.xml}:
      * {@code oid} (gml:id) and {@code idn} (gml:identifier); the surface geometry {@code gpo}
      * (position); the simple STRING {@code gfk} (gebaeudefunktion); the DATETIME {@code lzi_beg}
-     * (lebenszeitintervall) reached through an adv-namespaced valueWrap chain; the OBJECT_ARRAY
+     * (lebenszeitintervall) reached through an adv-namespaced xmlPaths chain; the OBJECT_ARRAY
      * {@code mat} (modellart) with {@code stm} / {@code som} children; the codelist VALUE_ARRAY
      * {@code anl} (anlass); the FEATURE_REF {@code hat}; and the deep transparent OBJECT chain
      * {@code qag} (qualitaetsangaben) → {@code dpl} (LI_Lineage) → {@code prs}
@@ -2831,11 +2828,11 @@ class FeatureTokenDecoderGmlSpec extends Specification {
                 .putObjectTypeNamespaces("LI_ProcessStep", "gmd")
                 .putObjectTypeNamespaces("LI_Source", "gmd")
                 .putObjectTypeNamespaces("CI_ResponsibleParty", "gmd")
-                // valueWrap is recognised under either the alias path or the property-name path;
+                // xmlPaths is recognised under either the alias path or the property-name path;
                 // exercise both shapes against the same fixture.
-                .putValueWrap("lebenszeitintervall", ["AA_Lebenszeitintervall", "beginnt"])
-                .putValueWrap("qag.dpl.prs.des", ["AX_LI_ProcessStep_MitDatenerhebung_Description"])
-                .putValueWrap("qag.dpl.prs.src.des", ["AX_Datenerhebung"])
+                .putXmlPaths("lebenszeitintervall", ["lebenszeitintervall", "AA_Lebenszeitintervall", "beginnt"])
+                .putXmlPaths("qag.dpl.prs.des", ["gmd:description", "AX_LI_ProcessStep_MitDatenerhebung_Description"])
+                .putXmlPaths("qag.dpl.prs.src.des", ["gmd:description", "AX_Datenerhebung"])
                 .codelistUriTemplate("https://registry.gdi-de.org/codelist/de.adv-online.gid/{{codelistId}}/{{value}}")
                 .featureRefTemplate("urn:adv:oid:{{value}}")
                 .build()
@@ -2877,7 +2874,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
         valueAtPath(tokens, ["gfk"]) == "2500"
     }
 
-    def 'AX_Gebaeude: valueWrap keyed by alias path decodes the wrapped scalar to the property source path'() {
+    def 'AX_Gebaeude: xmlPaths keyed by alias path decodes the wrapped scalar to the property source path'() {
         given:
         def decoder = newAxGebaeudeDecoder(axGebaeudeSchema(), axGebaeudeProfile())
         def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_PREFIX_URI}"
@@ -2914,7 +2911,7 @@ class FeatureTokenDecoderGmlSpec extends Specification {
         valueAtPath(tokens, ["oid"]) == "DENW36AL10000Egu"
         // gml:identifier (matched via the gml: prefix on the alias)
         valueAtPath(tokens, ["idn"]) == "urn:adv:oid:DENW36AL10000Egu"
-        // lebenszeitintervall/AA_Lebenszeitintervall/beginnt → lzi_beg (alias-keyed valueWrap)
+        // lebenszeitintervall/AA_Lebenszeitintervall/beginnt → lzi_beg (alias-keyed xmlPaths)
         valueAtPath(tokens, ["lzi_beg"]) == "2024-10-15T07:55:13Z"
         // gebaeudefunktion → gfk
         valueAtPath(tokens, ["gfk"]) == "2500"
@@ -2951,5 +2948,437 @@ class FeatureTokenDecoderGmlSpec extends Specification {
         def geometries = tokens.findAll { it instanceof Geometry } as List<Geometry>
         geometries.size() == 1
         pathBeforeGeometry(tokens) == ["gpo"]
+    }
+
+    // -------------------------------------------------------------------------------------------
+    // Structural xmlPaths chains: the mapped property is FLAT and its element chain names
+    // ancestor elements the schema does not contain — e.g. lzi_beg encoded as
+    // <lebenszeitintervall><AA_Lebenszeitintervall><beginnt>. The chain's elements match no
+    // property, so the decoder descends them transparently and resolves the innermost segment to
+    // the flat property. (When the first segment IS the property's own element — the option's
+    // value-wrapping use — the ordinary property lookup handles it; see the cases above.)
+    // -------------------------------------------------------------------------------------------
+
+    static final Map<String, String> TEST_NAMESPACES = [
+            "adv": ADV_NS,
+            "gmd": GMD_NS,
+            "gco": GCO_NS,
+            "gml": "http://www.opengis.net/gml/3.2",
+            "xlink": "http://www.w3.org/1999/xlink",
+            "xsi": "http://www.w3.org/2001/XMLSchema-instance"
+    ]
+
+    /**
+     * AX_Gebaeude where the lifespan is flat ({@code lzi_beg} / {@code
+     * lzi_end}), {@code mat} is a plain VALUE_ARRAY, the quality group is lifted to the flat {@code
+     * zpe} / {@code src} / {@code des}, and {@code fdv} keeps only {@code art} and {@code nam}. No
+     * property carries an alias — the XML element names come exclusively from the xmlPaths chains.
+     */
+    static FeatureSchema gebaeudeSchema() {
+        new ImmutableFeatureSchema.Builder()
+                .name("ax_gebaeude")
+                .sourcePath("/o31001")
+                .type(SchemaBase.Type.OBJECT)
+                .objectType("AX_Gebaeude")
+                .putProperties2("id", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("objid")
+                        .type(SchemaBase.Type.STRING)
+                        .role(SchemaBase.Role.ID))
+                .putProperties2("lzi_beg", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("lzi__beg")
+                        .type(SchemaBase.Type.DATETIME))
+                .putProperties2("lzi_end", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("lzi__endx")
+                        .type(SchemaBase.Type.DATETIME))
+                .putProperties2("mat", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("[id=rid]o31001__mat/stm")
+                        .type(SchemaBase.Type.VALUE_ARRAY)
+                        .valueType(SchemaBase.Type.STRING))
+                .putProperties2("gfk", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("gfk")
+                        .type(SchemaBase.Type.STRING)
+                        .alias("gebaeudefunktion"))
+                .putProperties2("fdv", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("[id=rid]o31001__fdv")
+                        .type(SchemaBase.Type.OBJECT_ARRAY)
+                        .objectType("AA_Fachdatenverbindung")
+                        .alias("zeigtAufExternes")
+                        .putProperties2("art", new ImmutableFeatureSchema.Builder()
+                                .sourcePath("art")
+                                .type(SchemaBase.Type.STRING)
+                                .alias("art"))
+                        .putProperties2("nam", new ImmutableFeatureSchema.Builder()
+                                .sourcePath("fdo__nam")
+                                .type(SchemaBase.Type.STRING)))
+                .putProperties2("vsg_wvs", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("vsg__wvs")
+                        .type(SchemaBase.Type.FLOAT))
+                .putProperties2("vsg_hvs", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("[id=rid]o14005__vsg__hvs/vsg__hvs")
+                        .type(SchemaBase.Type.VALUE_ARRAY)
+                        .valueType(SchemaBase.Type.FLOAT))
+                .putProperties2("des", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("qag__dpl_des")
+                        .type(SchemaBase.Type.STRING))
+                .putProperties2("zpe", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("qag__dpl_prs_dat")
+                        .type(SchemaBase.Type.DATETIME))
+                .putProperties2("src", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("qag__dpl_prs_src")
+                        .type(SchemaBase.Type.STRING))
+                .build()
+    }
+
+    static FeatureTokenDecoderGmlInputProfile gebaeudeProfile() {
+        ImmutableFeatureTokenDecoderGmlInputProfile.builder()
+                .useAlias(true)
+                .defaultNamespace("adv")
+                .putApplicationNamespaces("adv", ADV_NS)
+                .putApplicationNamespaces("gmd", GMD_NS)
+                .putApplicationNamespaces("gco", GCO_NS)
+                .putXmlPaths("lzi_beg", ["lebenszeitintervall", "AA_Lebenszeitintervall", "beginnt"])
+                .putXmlPaths("lzi_end", ["lebenszeitintervall", "AA_Lebenszeitintervall", "endet"])
+                .putXmlPaths("mat", ["modellart", "AA_Modellart", "advStandardModell"])
+                .putXmlPaths("fdv.nam", ["fachdatenobjekt", "AA_Fachdatenobjekt", "name"])
+                .putXmlPaths("vsg_wvs", ["vertikalerSchweregradient", "AX_VertikalerSchweregradient",
+                                         "wertVertikalerSchweregradient"])
+                .putXmlPaths("vsg_hvs", ["vertikalerSchweregradient", "AX_VertikalerSchweregradient",
+                                         "messhoeheVertikalerSchweregradient"])
+                .putXmlPaths("des", ["qualitaetsangaben", "AX_DQMitDatenerhebung", "herkunft",
+                                     "gmd:LI_Lineage", "gmd:processStep", "gmd:LI_ProcessStep",
+                                     "gmd:description", "AX_LI_ProcessStep_MitDatenerhebung_Description"])
+                .putXmlPaths("zpe", ["qualitaetsangaben", "AX_DQMitDatenerhebung", "herkunft",
+                                     "gmd:LI_Lineage", "gmd:processStep", "gmd:LI_ProcessStep",
+                                     "gmd:dateTime", "gco:DateTime"])
+                .putXmlPaths("src", ["qualitaetsangaben", "AX_DQMitDatenerhebung", "herkunft",
+                                     "gmd:LI_Lineage", "gmd:processStep", "gmd:LI_ProcessStep",
+                                     "gmd:source", "gmd:LI_Source", "gmd:description",
+                                     "AX_Datenerhebung"])
+                .build()
+    }
+
+    static FeatureTokenDecoderSimple<byte[], FeatureSchema, SchemaMapping, FeatureEventHandlerSimple.ModifiableContext<FeatureSchema, SchemaMapping>> newDecoder2(
+            FeatureSchema schema, FeatureTokenDecoderGmlInputProfile profile) {
+        new FeatureTokenDecoderGml(
+                TEST_NAMESPACES,
+                [new QName(ADV_NS, "AX_Gebaeude")],
+                schema,
+                ImmutableFeatureQuery.builder().type(schema.getName()).build(),
+                Map.of(schema.getName(),
+                        new ImmutableSchemaMapping.Builder()
+                                .targetSchema(schema)
+                                .sourcePathTransformer((path, isValue) -> path)
+                                .build()),
+                STORAGE_CRS,
+                Optional.empty(),
+                Optional.empty(),
+                profile)
+    }
+
+    def 'a structural chain resolves the flat property the chain maps'() {
+        given:
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:lebenszeitintervall>
+                <adv:AA_Lebenszeitintervall>
+                  <adv:beginnt>2009-11-04T14:25:08Z</adv:beginnt>
+                </adv:AA_Lebenszeitintervall>
+              </adv:lebenszeitintervall>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["lzi_beg"]) == "2009-11-04T14:25:08Z"
+    }
+
+    def 'properties merged into one wrapper instance both resolve'() {
+        given:
+        // The encoder keeps AA_Lebenszeitintervall open across lzi_beg and lzi_end; on input both
+        // children of the shared wrapper must resolve to their own flat property.
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010019MA6">
+              <adv:lebenszeitintervall>
+                <adv:AA_Lebenszeitintervall>
+                  <adv:beginnt>2020-10-08T05:53:29Z</adv:beginnt>
+                  <adv:endet>2026-01-12T10:30:46Z</adv:endet>
+                </adv:AA_Lebenszeitintervall>
+              </adv:lebenszeitintervall>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["lzi_beg"]) == "2020-10-08T05:53:29Z"
+        valueAtPath(tokens, ["lzi_end"]) == "2026-01-12T10:30:46Z"
+    }
+
+    def 'a sibling after a structural chain resolves at its own path'() {
+        given:
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:lebenszeitintervall>
+                <adv:AA_Lebenszeitintervall>
+                  <adv:beginnt>2009-11-04T14:25:08Z</adv:beginnt>
+                </adv:AA_Lebenszeitintervall>
+              </adv:lebenszeitintervall>
+              <adv:gebaeudefunktion>1000</adv:gebaeudefunktion>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["lzi_beg"]) == "2009-11-04T14:25:08Z"
+        valueAtPath(tokens, ["gfk"]) == "1000"
+    }
+
+    def 'a repeated chain brackets the multi-valued property in one ARRAY pair'() {
+        given:
+        // mat is a VALUE_ARRAY whose wire form is the repeated modellart chain; the ARRAY bracket
+        // belongs at the property path, spanning all repetitions.
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:modellart>
+                <adv:AA_Modellart>
+                  <adv:advStandardModell>DLKM</adv:advStandardModell>
+                </adv:AA_Modellart>
+              </adv:modellart>
+              <adv:modellart>
+                <adv:AA_Modellart>
+                  <adv:advStandardModell>Basis-DLM</adv:advStandardModell>
+                </adv:AA_Modellart>
+              </adv:modellart>
+              <adv:gebaeudefunktion>1000</adv:gebaeudefunktion>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY, ["mat"]) >= 0
+        indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY_END, ["mat"]) >= 0
+        tokens.count { it == FeatureTokenType.ARRAY } == 1
+        tokens.count { it == FeatureTokenType.ARRAY_END } == 1
+
+        and: 'both values sit inside the bracket, the following sibling outside'
+        def arrayStart = indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY, ["mat"])
+        def arrayEnd = indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY_END, ["mat"])
+        def values = indicesOfTokenAtPath(tokens, FeatureTokenType.VALUE, ["mat"])
+        values.size() == 2
+        values.every { it > arrayStart && it < arrayEnd }
+        indexOfTokenAtPath(tokens, FeatureTokenType.VALUE, ["gfk"]) > arrayEnd
+    }
+
+    def 'a repeated innermost chain element brackets its values in one ARRAY pair'() {
+        given: 'one wrapper holding a single-valued member and a multi-valued one'
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE860010007ZVh">
+              <adv:vertikalerSchweregradient>
+                <adv:AX_VertikalerSchweregradient>
+                  <adv:wertVertikalerSchweregradient>-0.000003214</adv:wertVertikalerSchweregradient>
+                  <adv:messhoeheVertikalerSchweregradient>123</adv:messhoeheVertikalerSchweregradient>
+                  <adv:messhoeheVertikalerSchweregradient>758</adv:messhoeheVertikalerSchweregradient>
+                </adv:AX_VertikalerSchweregradient>
+              </adv:vertikalerSchweregradient>
+              <adv:gebaeudefunktion>1000</adv:gebaeudefunktion>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then: 'both repetitions land inside a single bracket at the property path'
+        def arrayStart = indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY, ["vsg_hvs"])
+        def arrayEnd = indexOfTokenAtPath(tokens, FeatureTokenType.ARRAY_END, ["vsg_hvs"])
+        arrayStart >= 0 && arrayEnd > arrayStart
+        tokens.count { it == FeatureTokenType.ARRAY } == 1
+        tokens.count { it == FeatureTokenType.ARRAY_END } == 1
+        def values = indicesOfTokenAtPath(tokens, FeatureTokenType.VALUE, ["vsg_hvs"])
+        values.size() == 2
+        values.every { it > arrayStart && it < arrayEnd }
+
+        and: 'the single-valued member of the same wrapper stays outside the bracket'
+        def wvs = indexOfTokenAtPath(tokens, FeatureTokenType.VALUE, ["vsg_wvs"])
+        wvs >= 0 && wvs < arrayStart
+        indexOfTokenAtPath(tokens, FeatureTokenType.VALUE, ["gfk"]) > arrayEnd
+    }
+
+    def 'a structural chain inside an object array member resolves at the member path'() {
+        given:
+        // fdv.nam is mapped to fachdatenobjekt/AA_Fachdatenobjekt/name — a chain relative to the
+        // interior of the member object element, alongside the directly matched art.
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:zeigtAufExternes>
+                <adv:AA_Fachdatenverbindung>
+                  <adv:art>urn:rp:fdv:1030</adv:art>
+                  <adv:fachdatenobjekt>
+                    <adv:AA_Fachdatenobjekt>
+                      <adv:name>2021/00074199-SQ</adv:name>
+                    </adv:AA_Fachdatenobjekt>
+                  </adv:fachdatenobjekt>
+                </adv:AA_Fachdatenverbindung>
+              </adv:zeigtAufExternes>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["fdv", "art"]) == "urn:rp:fdv:1030"
+        valueAtPath(tokens, ["fdv", "nam"]) == "2021/00074199-SQ"
+    }
+
+    def 'the lifted quality group resolves to its flat properties'() {
+        given:
+        // The deep ISO 19115 chain carries three flat properties (des/zpe/src) merged into one
+        // LI_ProcessStep instance; each innermost value element resolves to its own property.
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gmd="${GMD_NS}" xmlns:gco="${GCO_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:qualitaetsangaben>
+                <adv:AX_DQMitDatenerhebung>
+                  <adv:herkunft>
+                    <gmd:LI_Lineage>
+                      <gmd:processStep>
+                        <gmd:LI_ProcessStep>
+                          <gmd:description>
+                            <adv:AX_LI_ProcessStep_MitDatenerhebung_Description>Erhebung</adv:AX_LI_ProcessStep_MitDatenerhebung_Description>
+                          </gmd:description>
+                          <gmd:dateTime>
+                            <gco:DateTime>2009-11-04T14:25:08Z</gco:DateTime>
+                          </gmd:dateTime>
+                          <gmd:source>
+                            <gmd:LI_Source>
+                              <gmd:description>
+                                <adv:AX_Datenerhebung>4200</adv:AX_Datenerhebung>
+                              </gmd:description>
+                            </gmd:LI_Source>
+                          </gmd:source>
+                        </gmd:LI_ProcessStep>
+                      </gmd:processStep>
+                    </gmd:LI_Lineage>
+                  </adv:herkunft>
+                </adv:AX_DQMitDatenerhebung>
+              </adv:qualitaetsangaben>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["des"]) == "Erhebung"
+        valueAtPath(tokens, ["zpe"]) == "2009-11-04T14:25:08Z"
+        valueAtPath(tokens, ["src"]) == "4200"
+    }
+
+        def 'an injected empty element is skipped and xsi:type on the value element is accepted'() {
+        given:
+        // The ISO 19139 quantitative-result shape: gmd:valueUnit is configured with a trailing '/'
+        // (written empty by the encoder, carrying only its attribute) and must be skipped on input,
+        // while the following gmd:value continues the chain and the anyType gco:Record carries the
+        // value plus an xsi:type the decoder drops.
+        def schema = new ImmutableFeatureSchema.Builder()
+                .name("ax_punktortau")
+                .sourcePath("/o14003")
+                .type(SchemaBase.Type.OBJECT)
+                .objectType("AX_PunktortAU")
+                .putProperties2("id", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("objid")
+                        .type(SchemaBase.Type.STRING)
+                        .role(SchemaBase.Role.ID))
+                .putProperties2("gwt", new ImmutableFeatureSchema.Builder()
+                        .sourcePath("q2d__gwt")
+                        .type(SchemaBase.Type.STRING))
+                .build()
+        def profile = ImmutableFeatureTokenDecoderGmlInputProfile.builder()
+                .useAlias(true)
+                .defaultNamespace("adv")
+                .putApplicationNamespaces("adv", ADV_NS)
+                .putApplicationNamespaces("gmd", GMD_NS)
+                .putApplicationNamespaces("gco", GCO_NS)
+                .putXmlPaths("gwt", ["genauigkeitswert", "gmd:DQ_RelativeInternalPositionalAccuracy",
+                                     "gmd:result", "gmd:DQ_QuantitativeResult",
+                                     "gmd:valueUnit[xlink:href=urn:adv:uom:m]/", "gmd:value",
+                                     "gco:Record[xsi:type=gml:doubleList]"])
+                .build()
+        def decoder = new FeatureTokenDecoderGml(
+                TEST_NAMESPACES,
+                [new QName(ADV_NS, "AX_PunktortAU")],
+                schema,
+                ImmutableFeatureQuery.builder().type(schema.getName()).build(),
+                Map.of(schema.getName(),
+                        new ImmutableSchemaMapping.Builder()
+                                .targetSchema(schema)
+                                .sourcePathTransformer((path, isValue) -> path)
+                                .build()),
+                STORAGE_CRS,
+                Optional.empty(),
+                Optional.empty(),
+                profile)
+        def xml = """<adv:AX_PunktortAU xmlns:adv="${ADV_NS}"
+                xmlns:gmd="${GMD_NS}" xmlns:gco="${GCO_NS}"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE680010005aR1">
+              <adv:genauigkeitswert>
+                <gmd:DQ_RelativeInternalPositionalAccuracy>
+                  <gmd:result>
+                    <gmd:DQ_QuantitativeResult>
+                      <gmd:valueUnit xlink:href="urn:adv:uom:m"/>
+                      <gmd:value>
+                        <gco:Record xsi:type="gml:doubleList">0.0074721</gco:Record>
+                      </gmd:value>
+                    </gmd:DQ_QuantitativeResult>
+                  </gmd:result>
+                </gmd:DQ_RelativeInternalPositionalAccuracy>
+              </adv:genauigkeitswert>
+            </adv:AX_PunktortAU>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["gwt"]) == "0.0074721"
+    }
+
+    def 'an unmapped element inside a structural chain is ignored'() {
+        given:
+        def decoder = newDecoder2(gebaeudeSchema(), gebaeudeProfile())
+        def xml = """<adv:AX_Gebaeude xmlns:adv="${ADV_NS}"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                gml:id="DEHE862010014RVJ">
+              <adv:lebenszeitintervall>
+                <adv:AA_Lebenszeitintervall>
+                  <adv:beginnt>2009-11-04T14:25:08Z</adv:beginnt>
+                  <adv:unbekannt>xyz</adv:unbekannt>
+                </adv:AA_Lebenszeitintervall>
+              </adv:lebenszeitintervall>
+              <adv:gebaeudefunktion>1000</adv:gebaeudefunktion>
+            </adv:AX_Gebaeude>"""
+
+        when:
+        def tokens = runDecoder(decoder, xml)
+
+        then:
+        valueAtPath(tokens, ["lzi_beg"]) == "2009-11-04T14:25:08Z"
+        valueAtPath(tokens, ["gfk"]) == "1000"
     }
 }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlMutationSession.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SqlMutationSession.java
@@ -1108,6 +1108,14 @@ public class SqlMutationSession implements FeatureTransactions.Session {
     }
 
     try {
+      // The junction patches run before the main-table UPDATE. Both locate the parent row with
+      // the same predicate, and on a retire-in-place update that predicate requires the version
+      // to still be open — which is exactly what the main-table SET is about to end. Patching
+      // afterwards would silently match no rows and drop the values.
+      for (JunctionPatch patch : junctionPatches.values()) {
+        runJunctionPatch(patch, mainTableName, idColumnName, idLiteral, extraWherePredicate, crs);
+      }
+
       if (!setClauses.isEmpty()) {
         String sql =
             "UPDATE "
@@ -1139,10 +1147,6 @@ public class SqlMutationSession implements FeatureTransactions.Session {
         for (String id : returned) {
           builder.addIds(id);
         }
-      }
-
-      for (JunctionPatch patch : junctionPatches.values()) {
-        runJunctionPatch(patch, mainTableName, idColumnName, idLiteral, extraWherePredicate, crs);
       }
 
       // No main-table SET ran but at least one junction was patched: confirm the feature exists.

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlMutationSessionSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlMutationSessionSpec.groovy
@@ -23,8 +23,8 @@ import spock.lang.Specification
  * </ul>
  *
  * The full insert/replace mutation path (driven via {@code FeatureMutationsSql} +
- * {@code FeatureEncoderSql} + a Reactive stream runner) needs a heavier fixture and is exercised
- * end-to-end via the gvd/alkis transactions smoke configuration.
+ * {@code FeatureEncoderSql} + a Reactive stream runner) needs a heavier fixture and has to be
+ * exercised end-to-end via a transactions smoke configuration.
  */
 class SqlMutationSessionSpec extends Specification {
 

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/VersionedMutationSqlSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/VersionedMutationSqlSpec.groovy
@@ -41,12 +41,11 @@ import java.time.Instant
  *
  * The actual Insert / Replace-insert SQL flows through
  * {@code FeatureMutationsSql} + {@code FeatureEncoderSql} which need a
- * full schema fixture; those paths are exercised end-to-end via the
- * gvd/alkis transactions smoke harness, not here.
+ * full schema fixture.
  */
 class VersionedMutationSqlSpec extends Specification {
 
-    static final String TABLE = 'o02340'                       // AP_PTO main table
+    static final String TABLE = 'o02340'
     static final String COL_ID = 'objid'
     static final String COL_START = 'lzi__beg'
     static final String COL_END = 'lzi__endx'

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/CrsVariants.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/CrsVariants.java
@@ -13,14 +13,14 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 /**
- * @langEn Some feature types store the same logical position in one of several CRSs — including
+ * @langEn Some feature types store the same logical position in one of several CRSs - including
  *     CRSs that cannot be expressed as the storage CRS of the property (realizations that map to
  *     the same coordinate reference system, or 1D vertical reference systems). Each variant is
  *     stored in its own property; `crsVariants` on the main geometry property declares which
  *     sibling properties hold the variants. All referenced properties must be siblings of the
  *     geometry property (properties of the same object) and are implicitly `internal`.
  * @langDe Manche Objektarten speichern dieselbe logische Position in einem von mehreren
- *     Koordinatenreferenzsystemen — einschließlich Systemen, die nicht als Speicher-CRS der
+ *     Koordinatenreferenzsystemen - einschließlich Systemen, die nicht als Speicher-CRS der
  *     Eigenschaft ausgedrückt werden können (Realisierungen, die auf dasselbe
  *     Koordinatenreferenzsystem abgebildet werden, oder eindimensionale Höhenreferenzsysteme). Jede
  *     Variante wird in einer eigenen Eigenschaft gespeichert; `crsVariants` an der

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
@@ -283,13 +283,13 @@ public interface FeatureSchema
   /**
    * @langEn Declares sibling properties that store the position of this geometry property in other
    *     reference systems, for feature types that store the same logical position in one of several
-   *     CRSs — including CRSs that cannot be expressed as a storage CRS (realizations that map to
+   *     CRSs - including CRSs that cannot be expressed as a storage CRS (realizations that map to
    *     the same coordinate reference system, or 1D vertical reference systems). Only relevant for
    *     properties with `type: GEOMETRY` in SQL feature providers. All referenced properties are
    *     implicitly `internal`. See [Position Variants](#position-variants).
    * @langDe Deklariert Nachbareigenschaften, die die Position dieser Geometrieeigenschaft in
    *     anderen Referenzsystemen speichern, für Objektarten, die dieselbe logische Position in
-   *     einem von mehreren Koordinatenreferenzsystemen speichern — einschließlich Systemen, die
+   *     einem von mehreren Koordinatenreferenzsystemen speichern - einschließlich Systemen, die
    *     nicht als Speicher-CRS ausgedrückt werden können (Realisierungen, die auf dasselbe
    *     Koordinatenreferenzsystem abgebildet werden, oder eindimensionale Höhenreferenzsysteme).
    *     Nur relevant für Eigenschaften mit `type: GEOMETRY` in SQL-Feature-Providern. Alle
@@ -323,7 +323,7 @@ public interface FeatureSchema
    *     `ORIGINAL_GEOMETRY`. When non-zero, the difference is added to the easting (the first
    *     ordinate) on input and subtracted on output, so the stored coordinates conform to
    *     `nativeCrs`. Example: German Gauss-Krüger coordinates written without the zone prefix use a
-   *     false easting of 500000, while EPSG:5677 (zone 3, E-N) defines 3500000 — the difference is
+   *     false easting of 500000, while EPSG:5677 (zone 3, E-N) defines 3500000 - the difference is
    *     3000000.
    * @langDe Die Differenz zwischen dem False Easting des Speicher-CRS (`nativeCrs`) und dem False
    *     Easting der Koordinaten, die eine der `originalCrsIdentifiers` dieser Eigenschaft
@@ -331,7 +331,7 @@ public interface FeatureSchema
    *     ungleich 0 wird die Differenz beim Einlesen zum Rechtswert (der ersten Ordinate) addiert
    *     und bei der Ausgabe subtrahiert, sodass die gespeicherten Koordinaten dem Speicher-CRS
    *     entsprechen. Beispiel: Gauß-Krüger-Koordinaten ohne Zonenkennzahl verwenden ein False
-   *     Easting von 500000, EPSG:5677 (Zone 3, E-N) definiert 3500000 — die Differenz beträgt
+   *     Easting von 500000, EPSG:5677 (Zone 3, E-N) definiert 3500000 - die Differenz beträgt
    *     3000000.
    * @default null
    * @since v4.8

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/MappingOperationResolver.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/MappingOperationResolver.java
@@ -245,7 +245,7 @@ import java.util.stream.Collectors;
  *     <p>#### Concat
  *     <p>Wenn die Werte für ein Array-Property oder für eine Objektart aus mehr als einem
  *     `sourcePath` stammen können, erlaubt diese Option alle verfügbaren Werte zu konkatenieren.
- *     <p>Bei Objektarten, die 'concat' verwenden, müssen die verschiedenen verketteten „Sub-Typen“
+ *     <p>Bei Objektarten, die 'concat' verwenden, müssen die verschiedenen verketteten "Sub-Typen"
  *     die folgenden Bedingungen erfüllen:
  *     <p><code>
  * - Alle ID-Eigenschaften müssen den gleichen Pfad und Typ haben.


### PR DESCRIPTION
A property whose wire form is an element chain has no element of its own: the chain's innermost segment carries the value. The decoder now resolves such chains, so a flat property round-trips through a nested XML structure.

- FeatureTokenDecoderGml: XML_PATH_CHAIN frames follow the chains that are still viable at each element, skip injected empty segments, accept xsi:type on the value element and emit the value at the property's own path.
- A chain whose innermost element repeats inside one wrapper feeds a multi-valued property: its values are bracketed as an ARRAY anchored at the property path. The bracket defers to one the enclosing container already opened when the whole chain repeats instead.
- FeatureTokenDecoderGmlInputProfile: xmlPaths carries the chains.
- FeatureTokenDecoderGmlSpec: chain decoding, the repeated innermost element, chains inside object array members, lifted property groups, empty segments and unmapped elements inside a chain.

Also adds a bugfix:

- SqlMutationSession: run the junction patches of an update before the main-table UPDATE. Both locate the parent row with the same predicate, and on a retire-in-place update that predicate requires the version to still be open - which the main-table SET ends. Patching afterwards matched no rows and dropped the values without reporting an error.
